### PR TITLE
feat: system program tests

### DIFF
--- a/packages/dynamic-instructions/src/features/instruction-encoding/validators.ts
+++ b/packages/dynamic-instructions/src/features/instruction-encoding/validators.ts
@@ -20,24 +20,24 @@ export function createIxAccountsValidator(ixAccountNodes: InstructionAccountNode
             acc[node.name] =
                 node.isOptional || node.defaultValue ? OptionalSolanaAddressValidator : SolanaAddressValidator;
             return acc;
-        }, {})
+        }, {}),
     );
 }
 
 export function createIxArgumentsValidator(
     ixNodeName: string,
     ixArgumentNodes: InstructionArgumentNode[],
-    definedTypes: DefinedTypeNode[]
+    definedTypes: DefinedTypeNode[],
 ): Struct {
     return object(
         ixArgumentNodes.reduce((acc, argumentNode, index) => {
             acc[argumentNode.name] = createValidatorForTypeNode(
                 `${ixNodeName}_${argumentNode.name}_${index}`,
                 argumentNode.type,
-                definedTypes
+                definedTypes,
             );
             return acc;
-        }, {})
+        }, {}),
     );
 }
 
@@ -88,7 +88,7 @@ function createValidatorForTypeNode(nodeName: string, node: TypeNode, definedTyp
             const valueValidator = createValidatorForTypeNode(
                 `${nodeName}_map_value_${node.key}`,
                 node.value,
-                definedTypes
+                definedTypes,
             );
             const sizeValidator = MapCountValidator(node.count);
             // node.
@@ -104,15 +104,15 @@ function createValidatorForTypeNode(nodeName: string, node: TypeNode, definedTyp
                     acc[node.name] = createValidatorForTypeNode(
                         `${nodeName}_struct_${node.name}`,
                         node.type,
-                        definedTypes
+                        definedTypes,
                     );
                     return acc;
-                }, {})
+                }, {}),
             );
         }
         case 'tupleTypeNode': {
             const validators = node.items.map((typeNode, index) =>
-                createValidatorForTypeNode(`${nodeName}_tuple${typeNode.kind}_${index}`, typeNode, definedTypes)
+                createValidatorForTypeNode(`${nodeName}_tuple${typeNode.kind}_${index}`, typeNode, definedTypes),
             );
             return tuple(validators as [Struct<unknown, unknown>, ...Struct<unknown, unknown>[]]);
         }
@@ -134,7 +134,12 @@ function createValidatorForTypeNode(nodeName: string, node: TypeNode, definedTyp
         case 'sentinelTypeNode':
         case 'postOffsetTypeNode':
         case 'preOffsetTypeNode':
-        case 'sizePrefixTypeNode':
+        case 'sizePrefixTypeNode': {
+            // Size-prefixed type (e.g. length-prefixed string); validate the inner type only
+            // Cast to access the type property which exists on sizePrefixTypeNode
+            const sizePrefixNode = node as TypeNode & { type: TypeNode };
+            return createValidatorForTypeNode(`${nodeName}_size_prefix`, sizePrefixNode.type, definedTypes);
+        }
         case 'enumTypeNode':
             throw new Error(`Unsupported argument type: ${nodeName} of type ${node.kind}`);
     }

--- a/packages/dynamic-instructions/tests/anchor/tests/idl.spec.ts
+++ b/packages/dynamic-instructions/tests/anchor/tests/idl.spec.ts
@@ -1,160 +1,125 @@
-import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { getNodeCodec } from '@codama/dynamic-codecs';
-import { address } from '@solana/addresses';
-import type { Option } from '@solana/codecs';
-import { unwrapOption } from '@solana/codecs';
-import type { Instruction } from '@solana/instructions';
-import * as web3 from '@solana/web3.js';
+import type { Address } from '@solana/addresses';
+import { unwrapOption, type Option } from '@solana/codecs';
 import type { RootNode } from 'codama';
-import { LiteSVM } from 'litesvm';
 import { beforeEach, describe, expect, test } from 'vitest';
 
-import { createProgramClient, toLegacyTransactionInstruction } from '../../../src';
-
-function sendTx(svm: LiteSVM, ix: Instruction, signers: web3.Keypair[]) {
-    if (signers.length === 0) throw new Error('sendTx: expected at least 1 signer');
-
-    const tx = new web3.Transaction().add(toLegacyTransactionInstruction(ix));
-    tx.feePayer = signers[0].publicKey;
-    tx.recentBlockhash = svm.latestBlockhash();
-    tx.sign(...signers);
-
-    const sig = svm.sendTransaction(tx);
-    return { sig, tx };
-}
+import { createProgramClient } from '../../../src';
+import { loadIdl, SvmTestContext } from '../../test-utils';
 
 describe('anchor-example', () => {
-    const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+    const prebuiltIdlsDir = path.resolve(__dirname, '..', 'prebuilt-idls');
+    const idl = loadIdl('example-idl.json', prebuiltIdlsDir);
 
-    const idlPath = path.resolve(__dirname, '..', 'prebuilt-idls', 'example-idl.json');
-    const idlJson: unknown = JSON.parse(readFileSync(idlPath, 'utf8'));
-    if (typeof idlJson !== 'object' || idlJson === null) throw new Error('Invalid IDL json');
-    const programClient = createProgramClient(idlJson);
-    const programId = new web3.PublicKey(programClient.programAddress);
+    const programClient = createProgramClient(idl);
 
     const programSoPath = path.resolve(__dirname, '..', 'target', 'deploy', 'example.so');
 
-    let svm: LiteSVM;
-    let payerKp: web3.Keypair;
+    let ctx: SvmTestContext;
+    let payer: Address;
 
-    beforeEach(async () => {
-        svm = new LiteSVM();
-        svm.addProgramFromFile(programId, programSoPath);
-
-        payerKp = web3.Keypair.generate();
-        svm.airdrop(payerKp.publicKey, BigInt(10e9)); // 10 SOL
-        await sleep(1);
+    beforeEach(() => {
+        ctx = new SvmTestContext();
+        ctx.loadProgram(programClient.programAddress, programSoPath);
+        payer = ctx.createFundedAccount();
     });
 
-    test('PubkeySeedIx', async () => {
-        const ix = await programClient.methods
-            .pubkeySeedIx({ input: 42 })
-            .accounts({
-                signer: address(payerKp.publicKey.toBase58()),
-            })
-            .instruction();
+    describe('pubkeySeedIx', () => {
+        test('should execute instruction with pubkey seed', async () => {
+            const ix = await programClient.methods
+                .pubkeySeedIx({ input: 42 })
+                .accounts({ signer: payer })
+                .instruction();
 
-        const { sig } = sendTx(svm, ix, [payerKp]);
-        console.log('Transaction signature:', sig);
+            ctx.sendInstruction(ix, [payer]);
+        });
     });
 
-    test('UpdateOptionalInput', async () => {
-        const signerKp = web3.Keypair.generate();
-        svm.airdrop(signerKp.publicKey, BigInt(1e9)); // 1 SOL
-        await sleep(1);
-        const signerAddress = address(signerKp.publicKey.toBase58());
+    describe('updateOptionalInput', () => {
+        test('should update optional input field with and without value', async () => {
+            const signer = ctx.createFundedAccount();
 
-        const ix0 = await programClient.methods
-            .pubkeySeedIx({ input: 42 })
-            .accounts({ signer: signerAddress })
-            .instruction();
+            const ix0 = await programClient.methods.pubkeySeedIx({ input: 42 }).accounts({ signer }).instruction();
 
-        sendTx(svm, ix0, [signerKp]);
+            ctx.sendInstruction(ix0, [signer]);
 
-        // Test case 1: With optional input
-        const optionalAddress = web3.Keypair.generate().publicKey.toBase58();
-        const ix1 = await programClient.methods
-            .updateOptionalInput({
-                input: 44,
-                optionalInput: optionalAddress,
-            })
-            .accounts({ signer: signerAddress })
-            .instruction();
+            const pda = ctx.findProgramAddress(
+                [
+                    { type: 'string', value: 'seed' },
+                    { type: 'address', value: signer },
+                ],
+                programClient.programAddress,
+            );
 
-        const [accAddress] = web3.PublicKey.findProgramAddressSync(
-            [Buffer.from('seed'), new web3.PublicKey(signerAddress).toBuffer()],
-            programId,
-        );
-        const accAddresss = accAddress.toBase58();
+            const optionalAddress = ctx.createAccount();
+            const ix1 = await programClient.methods
+                .updateOptionalInput({
+                    input: 44,
+                    optionalInput: optionalAddress,
+                })
+                .accounts({ signer })
+                .instruction();
 
-        const { sig } = sendTx(svm, ix1, [signerKp]);
-        console.log('Transaction signature (with provided optional input):', sig);
+            ctx.sendInstruction(ix1, [signer]);
 
-        const accInfo = svm.getAccount(new web3.PublicKey(accAddresss));
-        expect(accInfo).toBeTruthy();
-        if (!accInfo) throw new Error('Expected account to exist');
-        const decoded1 = decodeDataAccount1(programClient.root, accInfo.data);
-        expect(decoded1.optionalInput).eq(optionalAddress);
+            const account1 = ctx.requireEncodedAccount(pda);
+            const decoded1 = decodeDataAccount1(programClient.root, account1.data);
+            expect(decoded1.optionalInput).eq(optionalAddress);
 
-        // Test case 2: Without optional input
-        const ix2 = await programClient.methods
-            .updateOptionalInput({
-                input: 45,
-            })
-            .accounts({ signer: signerAddress })
-            .instruction();
+            const ix2 = await programClient.methods
+                .updateOptionalInput({ input: 45 })
+                .accounts({ signer })
+                .instruction();
 
-        sendTx(svm, ix2, [signerKp]);
-        await sleep(1);
+            ctx.sendInstruction(ix2, [signer]);
 
-        const accInfoAfter = svm.getAccount(new web3.PublicKey(accAddresss));
-        expect(accInfoAfter).toBeTruthy();
-        if (!accInfoAfter) throw new Error('Expected account to exist');
-        const decoded2 = decodeDataAccount1(programClient.root, accInfoAfter.data);
-        expect(decoded2.optionalInput).toBeNull();
+            const account2 = ctx.requireEncodedAccount(pda);
+            const decoded2 = decodeDataAccount1(programClient.root, account2.data);
+            expect(decoded2.optionalInput).toBeNull();
+        });
     });
 
-    test('UpdateOptionalAccount', async () => {
-        // Test case 1: With optional account
-        const optionalAddress = web3.Keypair.generate().publicKey.toBase58();
-        let ix = await programClient.methods
-            .updateOptionalAccount({ id: 1 })
-            .accounts({
-                optionalAccKey: optionalAddress,
-                signer: address(payerKp.publicKey.toBase58()),
-            })
-            .instruction();
+    describe('updateOptionalAccount', () => {
+        test('should handle optional accounts', async () => {
+            const optionalAccount = ctx.createAccount();
+            const ix1 = await programClient.methods
+                .updateOptionalAccount({ id: 1 })
+                .accounts({
+                    optionalAccKey: optionalAccount,
+                    signer: payer,
+                })
+                .instruction();
 
-        let { sig } = sendTx(svm, ix, [payerKp]);
-        console.log('Transaction signature (with optional account):', sig);
+            ctx.sendInstruction(ix1, [payer]);
 
-        // Test case 2: Without optional account
-        ix = await programClient.methods
-            .updateOptionalAccount({ id: 2 })
-            .accounts({
-                optionalAccKey: null,
-                signer: address(payerKp.publicKey.toBase58()),
-            })
-            .instruction();
+            const ix2 = await programClient.methods
+                .updateOptionalAccount({ id: 2 })
+                .accounts({
+                    optionalAccKey: null,
+                    signer: payer,
+                })
+                .instruction();
 
-        ({ sig } = sendTx(svm, ix, [payerKp]));
-        console.log('Transaction signature (without optional account):', sig);
+            ctx.sendInstruction(ix2, [payer]);
+        });
     });
 
-    test('NoArguments', async () => {
-        const kp = web3.Keypair.generate();
-        const ix = await programClient.methods
-            .noArguments()
-            .accounts({
-                acc: address(kp.publicKey.toBase58()),
-                signer: address(payerKp.publicKey.toBase58()),
-            })
-            .instruction();
-        const { sig } = sendTx(svm, ix, [payerKp, kp]);
+    describe('noArguments', () => {
+        test('should execute instruction with no arguments', async () => {
+            const account = ctx.createAccount();
 
-        console.log('Transaction signature', sig);
+            const ix = await programClient.methods
+                .noArguments()
+                .accounts({
+                    acc: account,
+                    signer: payer,
+                })
+                .instruction();
+
+            ctx.sendInstruction(ix, [payer, account]);
+        });
     });
 });
 
@@ -163,9 +128,10 @@ function decodeDataAccount1(
     data: Uint8Array,
 ): { bump: number; input: bigint; optionalInput: string | null } {
     const accountNode = root.program.accounts.find(a => a.name === 'dataAccount1');
-    if (!accountNode) throw new Error('Could not find account node "dataAccount1" in IDL');
+    if (!accountNode) {
+        throw new Error('Could not find account node "dataAccount1" in IDL');
+    }
 
-    // This codec is derived from the Codama IDL; it handles discriminator + optional encoding.
     const codec = getNodeCodec([root, root.program, accountNode]);
     const decoded = codec.decode(Uint8Array.from(data)) as {
         bump: number;

--- a/packages/dynamic-instructions/tests/svm-test-context.ts
+++ b/packages/dynamic-instructions/tests/svm-test-context.ts
@@ -17,6 +17,16 @@ export type EncodedAccount = {
 };
 
 /**
+ * Configuration options for the SVM test context.
+ */
+export type SvmTestContextConfig = {
+    /** Include standard SPL programs (Token, Token-2022, ATA, etc.). Default: false. */
+    readonly defaultPrograms?: boolean;
+    /** Include standard precompiles (ed25519, secp256k1). Default: false. */
+    readonly precompiles?: boolean;
+};
+
+/**
  * Test context that encapsulates LiteSVM and provides a clean Solana Kit API.
  *
  * Purpose:
@@ -27,14 +37,24 @@ export type EncodedAccount = {
  *
  * Tests work exclusively with Address types while the context handles
  * keypair management and transaction building behind the scenes.
+ *
+ * By default, the context includes standard builtins (system program, etc.)
+ * and sysvars. Use the config parameter to include additional programs.
  */
 export class SvmTestContext {
     private readonly svm: LiteSVM;
     private readonly accounts: Map<Address, web3.Keypair>;
     private currentSlot: bigint;
 
-    constructor() {
-        this.svm = new LiteSVM();
+    constructor(config: SvmTestContextConfig = {}) {
+        let svm = new LiteSVM();
+        if (config.defaultPrograms) {
+            svm = svm.withDefaultPrograms();
+        }
+        if (config.precompiles) {
+            svm = svm.withPrecompiles();
+        }
+        this.svm = svm;
         this.accounts = new Map();
         this.currentSlot = BigInt(0);
     }

--- a/packages/dynamic-instructions/tests/svm-test-context.ts
+++ b/packages/dynamic-instructions/tests/svm-test-context.ts
@@ -1,0 +1,214 @@
+import { address, type Address } from '@solana/addresses';
+import type { Instruction } from '@solana/instructions';
+import * as web3 from '@solana/web3.js';
+import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
+
+import { toLegacyTransactionInstruction } from '../src';
+
+/**
+ * Encoded account data returned from SVM.
+ */
+export type EncodedAccount = {
+    readonly lamports: bigint;
+    readonly owner: Address;
+    readonly data: Uint8Array;
+    readonly executable: boolean;
+    readonly rentEpoch?: bigint;
+};
+
+/**
+ * Test context that encapsulates LiteSVM and provides a clean Solana Kit API.
+ *
+ * Purpose:
+ * - Hides legacy web3.js types and LiteSVM implementation details
+ * - Exposes only modern Solana Kit types (Address, Instruction)
+ * - Manages account lifecycle and signing internally
+ * - Provides declarative test helpers (fundAccount, sendInstruction)
+ *
+ * Tests work exclusively with Address types while the context handles
+ * keypair management and transaction building behind the scenes.
+ */
+export class SvmTestContext {
+    private readonly svm: LiteSVM;
+    private readonly accounts: Map<Address, web3.Keypair>;
+    private currentSlot: bigint;
+
+    constructor() {
+        this.svm = new LiteSVM();
+        this.accounts = new Map();
+        this.currentSlot = BigInt(0);
+    }
+
+    /** Creates a new keypair, stores it in the context, and returns its address. */
+    createAccount(): Address {
+        const keypair = web3.Keypair.generate();
+        const addr = address(keypair.publicKey.toBase58());
+        this.accounts.set(addr, keypair);
+        return addr;
+    }
+
+    /** Creates an account and airdrops the given lamports to it. */
+    createFundedAccount(lamports: bigint = BigInt(10e9)): Address {
+        const addr = this.createAccount();
+        const keypair = this.accounts.get(addr);
+        this.svm.airdrop(keypair.publicKey, lamports);
+        return addr;
+    }
+
+    /** Derives an address from base + seed + programId (createWithSeed). Does not store a keypair. */
+    async createAccountWithSeed(base: Address, seed: string, programId: Address): Promise<Address> {
+        const derived = await web3.PublicKey.createWithSeed(
+            new web3.PublicKey(base),
+            seed,
+            new web3.PublicKey(programId),
+        );
+        return address(derived.toBase58());
+    }
+
+    /** Airdrops lamports to an account. Account must have been created via this context. */
+    airdrop(account: Address, lamports: bigint = BigInt(1e9)): void {
+        const keypair = this.accounts.get(account);
+        if (!keypair) {
+            throw new Error(`Account ${account} not found in context`);
+        }
+        this.svm.airdrop(keypair.publicKey, lamports);
+    }
+
+    /** Returns the account's lamport balance, or null if the account is unknown to the SVM. */
+    getBalance(account: Address): bigint | null {
+        const keypair = this.accounts.get(account);
+        if (!keypair) {
+            return this.svm.getBalance(new web3.PublicKey(account));
+        }
+        return this.svm.getBalance(keypair.publicKey);
+    }
+
+    /** Same as getBalance but returns 0n when the account is missing. */
+    getBalanceOrZero(account: Address): bigint {
+        return this.getBalance(account) ?? BigInt(0);
+    }
+
+    /** Fetches full account data (lamports, owner, data, executable). Returns null if not found. */
+    fetchEncodedAccount(account: Address): EncodedAccount | null {
+        const keypair = this.accounts.get(account);
+        const pubkey = keypair ? keypair.publicKey : new web3.PublicKey(account);
+        const accountInfo = this.svm.getAccount(pubkey);
+
+        if (!accountInfo) {
+            return null;
+        }
+
+        return {
+            lamports: BigInt(accountInfo.lamports),
+            owner: address(accountInfo.owner.toBase58()),
+            data: accountInfo.data,
+            executable: accountInfo.executable,
+            rentEpoch: accountInfo.rentEpoch !== undefined ? BigInt(accountInfo.rentEpoch) : undefined,
+        };
+    }
+
+    /** Like fetchEncodedAccount but throws if the account does not exist. */
+    requireEncodedAccount(account: Address): EncodedAccount {
+        const encodedAccount = this.fetchEncodedAccount(account);
+        if (!encodedAccount) {
+            throw new Error(`Account ${account} does not exist`);
+        }
+        return encodedAccount;
+    }
+
+    /** Builds, signs, and sends a transaction with a single instruction. Signers must be context-owned. */
+    sendInstruction(instruction: Instruction, signers: Address[]): void {
+        if (signers.length === 0) {
+            throw new Error('At least one signer is required');
+        }
+
+        const keypairs = signers.map(addr => {
+            const keypair = this.accounts.get(addr);
+            if (!keypair) {
+                throw new Error(`Signer ${addr} not found in context`);
+            }
+            return keypair;
+        });
+
+        const legacyIx = toLegacyTransactionInstruction(instruction);
+        const transaction = new web3.Transaction().add(legacyIx);
+        transaction.feePayer = keypairs[0].publicKey;
+        transaction.recentBlockhash = this.svm.latestBlockhash();
+        transaction.sign(...keypairs);
+
+        const result = this.svm.sendTransaction(transaction);
+        if (result instanceof FailedTransactionMetadata) {
+            throw new Error(`Transaction failed: ${result.toString()}`);
+        }
+    }
+
+    /** Builds, signs, and sends a transaction with multiple instructions. Signers must be context-owned. */
+    sendInstructions(instructions: Instruction[], signers: Address[]): void {
+        if (signers.length === 0) {
+            throw new Error('At least one signer is required');
+        }
+
+        const keypairs = signers.map(addr => {
+            const keypair = this.accounts.get(addr);
+            if (!keypair) {
+                throw new Error(`Signer ${addr} not found in context`);
+            }
+            return keypair;
+        });
+
+        const transaction = new web3.Transaction();
+        for (const instruction of instructions) {
+            const legacyIx = toLegacyTransactionInstruction(instruction);
+            transaction.add(legacyIx);
+        }
+
+        transaction.feePayer = keypairs[0].publicKey;
+        transaction.recentBlockhash = this.svm.latestBlockhash();
+        transaction.sign(...keypairs);
+
+        const result = this.svm.sendTransaction(transaction);
+        if (result instanceof FailedTransactionMetadata) {
+            throw new Error(`Transaction failed: ${result.toString()}`);
+        }
+    }
+
+    /** Warps the SVM to the specified slot. */
+    warpToSlot(slot: bigint): void {
+        this.currentSlot = slot;
+        this.svm.warpToSlot(slot);
+    }
+
+    /** Advances the SVM by the specified number of slots (default: 1). */
+    advanceSlots(count: bigint = BigInt(1)): void {
+        this.currentSlot += count;
+        this.svm.warpToSlot(this.currentSlot);
+        this.svm.expireBlockhash();
+    }
+
+    /** Loads a Solana program from a .so file. */
+    loadProgram(programAddress: Address, programPath: string): void {
+        const programId = new web3.PublicKey(programAddress);
+        this.svm.addProgramFromFile(programId, programPath);
+    }
+
+    /** Derives a Program Derived Address (PDA) from seeds and program ID. */
+    findProgramAddress(
+        seeds: Array<{ readonly type: 'string' | 'bytes' | 'address'; readonly value: string | Uint8Array | Address }>,
+        programId: Address,
+    ): Address {
+        const seedBuffers = seeds.map(seed => {
+            if (seed.type === 'string') return Buffer.from(seed.value as string, 'utf8');
+            if (seed.type === 'bytes') return Buffer.from(seed.value as Uint8Array);
+            return new web3.PublicKey(seed.value as Address).toBuffer();
+        });
+
+        const [pdaKey] = web3.PublicKey.findProgramAddressSync(seedBuffers, new web3.PublicKey(programId));
+
+        return address(pdaKey.toBase58());
+    }
+
+    /** Returns the underlying LiteSVM instance for direct use when needed. Consider using the public methods instead. */
+    getSvm(): LiteSVM {
+        return this.svm;
+    }
+}

--- a/packages/dynamic-instructions/tests/system-program/advance-nonce-account.test.ts
+++ b/packages/dynamic-instructions/tests/system-program/advance-nonce-account.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { createTestProgramClient, SvmTestContext } from '../test-utils';
+
+describe('System Program: advanceNonceAccount', () => {
+    const programClient = createTestProgramClient('system-program-idl.json');
+    let ctx: SvmTestContext;
+
+    beforeEach(() => {
+        ctx = new SvmTestContext();
+    });
+
+    test('should advance nonce multiple times and work after authority change', async () => {
+        const payer = ctx.createFundedAccount();
+        const nonceAccount = ctx.createAccount();
+        const originalAuthority = ctx.createFundedAccount();
+        const newAuthority = ctx.createFundedAccount();
+
+        const nonceAccountSpace = 80;
+        const fundingLamports = 10_000_000;
+
+        const createAccountInstruction = await programClient.methods
+            .createAccount({
+                lamports: fundingLamports,
+                space: nonceAccountSpace,
+                programAddress: programClient.programAddress,
+            })
+            .accounts({
+                payer,
+                newAccount: nonceAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(createAccountInstruction, [payer, nonceAccount]);
+
+        const initializeNonceInstruction = await programClient.methods
+            .initializeNonceAccount({
+                nonceAuthority: originalAuthority,
+            })
+            .accounts({
+                nonceAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(initializeNonceInstruction, [payer]);
+
+        const initialData = ctx.requireEncodedAccount(nonceAccount).data;
+
+        ctx.advanceSlots();
+        const advanceNonceInstruction1 = await programClient.methods
+            .advanceNonceAccount()
+            .accounts({
+                nonceAccount,
+                nonceAuthority: originalAuthority,
+            })
+            .instruction();
+
+        ctx.sendInstruction(advanceNonceInstruction1, [originalAuthority]);
+
+        const dataAfterFirstAdvance = ctx.requireEncodedAccount(nonceAccount).data;
+        expect(dataAfterFirstAdvance).not.toEqual(initialData);
+
+        ctx.advanceSlots();
+        const advanceNonceInstruction2 = await programClient.methods
+            .advanceNonceAccount()
+            .accounts({
+                nonceAccount,
+                nonceAuthority: originalAuthority,
+            })
+            .instruction();
+
+        ctx.sendInstruction(advanceNonceInstruction2, [originalAuthority]);
+
+        const dataAfterSecondAdvance = ctx.requireEncodedAccount(nonceAccount).data;
+        expect(dataAfterSecondAdvance).not.toEqual(dataAfterFirstAdvance);
+
+        const authorizeNonceInstruction = await programClient.methods
+            .authorizeNonceAccount({
+                newNonceAuthority: newAuthority,
+            })
+            .accounts({
+                nonceAccount,
+                nonceAuthority: originalAuthority,
+            })
+            .instruction();
+
+        ctx.sendInstruction(authorizeNonceInstruction, [originalAuthority]);
+
+        ctx.advanceSlots();
+        const advanceWithNewAuthority = await programClient.methods
+            .advanceNonceAccount()
+            .accounts({
+                nonceAccount,
+                nonceAuthority: newAuthority,
+            })
+            .instruction();
+
+        ctx.sendInstruction(advanceWithNewAuthority, [newAuthority]);
+
+        const finalAccount = ctx.requireEncodedAccount(nonceAccount);
+        expect(finalAccount).toMatchObject({
+            lamports: BigInt(fundingLamports),
+            owner: programClient.programAddress,
+            executable: false,
+        });
+        expect(finalAccount.data.length).toBe(nonceAccountSpace);
+    });
+});

--- a/packages/dynamic-instructions/tests/system-program/allocate-with-seed.test.ts
+++ b/packages/dynamic-instructions/tests/system-program/allocate-with-seed.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { createTestProgramClient, SvmTestContext } from '../test-utils';
+
+describe('System Program: allocateWithSeed', () => {
+    const programClient = createTestProgramClient('system-program-idl.json');
+    let ctx: SvmTestContext;
+
+    beforeEach(() => {
+        ctx = new SvmTestContext();
+    });
+
+    test('should allocate space for a seed-derived account', async () => {
+        const payerAccount = ctx.createFundedAccount();
+        const baseAccount = ctx.createFundedAccount();
+
+        const seed = 'storage';
+        const newAccount = await ctx.createAccountWithSeed(baseAccount, seed, programClient.programAddress);
+
+        const fundingLamports = 5_000_000;
+        const createIx = await programClient.methods
+            .createAccountWithSeed({
+                base: baseAccount,
+                seed,
+                amount: fundingLamports,
+                space: 0,
+                programAddress: programClient.programAddress,
+            })
+            .accounts({
+                payer: payerAccount,
+                newAccount,
+                baseAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(createIx, [payerAccount, baseAccount]);
+
+        const space = 96;
+        const allocateIx = await programClient.methods
+            .allocateWithSeed({
+                base: baseAccount,
+                seed,
+                space,
+                programAddress: programClient.programAddress,
+            })
+            .accounts({
+                newAccount,
+                baseAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(allocateIx, [baseAccount]);
+
+        const accountAfter = ctx.requireEncodedAccount(newAccount);
+
+        expect(accountAfter).toMatchObject({
+            owner: programClient.programAddress,
+            data: new Uint8Array(space),
+        });
+    });
+});

--- a/packages/dynamic-instructions/tests/system-program/allocate.test.ts
+++ b/packages/dynamic-instructions/tests/system-program/allocate.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { createTestProgramClient, SvmTestContext } from '../test-utils';
+
+describe('System Program: allocate', () => {
+    const programClient = createTestProgramClient('system-program-idl.json');
+    let ctx: SvmTestContext;
+
+    beforeEach(() => {
+        ctx = new SvmTestContext();
+    });
+
+    test('should allocate space for an account', async () => {
+        const account = ctx.createFundedAccount();
+        const space = 100;
+
+        const accountBefore = ctx.requireEncodedAccount(account);
+        expect(accountBefore.data.length).toBe(0);
+
+        const instruction = await programClient.methods
+            .allocate({ space })
+            .accounts({ newAccount: account })
+            .instruction();
+
+        ctx.sendInstruction(instruction, [account]);
+
+        const accountAfter = ctx.requireEncodedAccount(account);
+
+        expect(accountAfter).toMatchObject({
+            owner: programClient.programAddress,
+        });
+        expect(accountAfter.data.length).toBe(space);
+        expect(accountAfter.lamports).toBeLessThan(accountBefore.lamports);
+        expect(accountAfter.data.every(byte => byte === 0)).toBe(true);
+    });
+});

--- a/packages/dynamic-instructions/tests/system-program/assign-with-seed.test.ts
+++ b/packages/dynamic-instructions/tests/system-program/assign-with-seed.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { createTestProgramClient, SvmTestContext } from '../test-utils';
+
+describe('System Program: assignWithSeed', () => {
+    const programClient = createTestProgramClient('system-program-idl.json');
+    let ctx: SvmTestContext;
+
+    beforeEach(() => {
+        ctx = new SvmTestContext();
+    });
+
+    test('should assign seed-derived account to system program', async () => {
+        const payerAccount = ctx.createFundedAccount();
+        const baseAccount = ctx.createFundedAccount();
+
+        const seed = 'wallet';
+        const account = await ctx.createAccountWithSeed(baseAccount, seed, programClient.programAddress);
+
+        const createIx = await programClient.methods
+            .createAccountWithSeed({
+                base: baseAccount,
+                seed,
+                amount: 5_000_000,
+                space: 32,
+                programAddress: programClient.programAddress,
+            })
+            .accounts({
+                payer: payerAccount,
+                newAccount: account,
+                baseAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(createIx, [payerAccount, baseAccount]);
+
+        const assignIx = await programClient.methods
+            .assignWithSeed({
+                base: baseAccount,
+                seed,
+                programAddress: programClient.programAddress,
+            })
+            .accounts({
+                account,
+                baseAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(assignIx, [baseAccount]);
+
+        expect(ctx.requireEncodedAccount(account)).toMatchObject({
+            owner: programClient.programAddress,
+        });
+    });
+});

--- a/packages/dynamic-instructions/tests/system-program/assign.test.ts
+++ b/packages/dynamic-instructions/tests/system-program/assign.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { createTestProgramClient, SvmTestContext } from '../test-utils';
+
+describe('System Program: assign', () => {
+    const programClient = createTestProgramClient('system-program-idl.json');
+    let ctx: SvmTestContext;
+
+    beforeEach(() => {
+        ctx = new SvmTestContext();
+    });
+
+    test('should assign a new owner to an account', async () => {
+        const payer = ctx.createFundedAccount();
+        const accountToAssign = ctx.createAccount();
+        const newOwner = ctx.createAccount();
+        const amount = 1_000_000;
+
+        const transferInstruction = await programClient.methods
+            .transferSol({ amount })
+            .accounts({
+                source: payer,
+                destination: accountToAssign,
+            })
+            .instruction();
+
+        const assignInstruction = await programClient.methods
+            .assign({ programAddress: newOwner })
+            .accounts({ account: accountToAssign })
+            .instruction();
+
+        ctx.sendInstructions([transferInstruction, assignInstruction], [payer, accountToAssign]);
+
+        expect(ctx.requireEncodedAccount(accountToAssign)).toMatchObject({
+            lamports: BigInt(amount),
+            owner: newOwner,
+        });
+    });
+
+    test('should assign account to system program', async () => {
+        const account = ctx.createFundedAccount();
+
+        const instruction = await programClient.methods
+            .assign({ programAddress: programClient.programAddress })
+            .accounts({ account: account })
+            .instruction();
+
+        ctx.sendInstruction(instruction, [account]);
+
+        const encodedAccount = ctx.requireEncodedAccount(account);
+        expect(encodedAccount).toMatchObject({
+            owner: programClient.programAddress,
+        });
+    });
+});

--- a/packages/dynamic-instructions/tests/system-program/authorize-nonce-account.test.ts
+++ b/packages/dynamic-instructions/tests/system-program/authorize-nonce-account.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { createTestProgramClient, SvmTestContext } from '../test-utils';
+
+describe('System Program: authorizeNonceAccount', () => {
+    const programClient = createTestProgramClient('system-program-idl.json');
+    let ctx: SvmTestContext;
+
+    beforeEach(() => {
+        ctx = new SvmTestContext();
+    });
+
+    test('should change nonce account authority to a new authority', async () => {
+        const payer = ctx.createFundedAccount();
+        const nonceAccount = ctx.createAccount();
+        const originalAuthority = ctx.createFundedAccount();
+        const newAuthority = ctx.createAccount();
+
+        const nonceAccountSpace = 80;
+        const fundingLamports = 10_000_000;
+
+        const createAccountInstruction = await programClient.methods
+            .createAccount({
+                lamports: fundingLamports,
+                space: nonceAccountSpace,
+                programAddress: programClient.programAddress,
+            })
+            .accounts({
+                payer,
+                newAccount: nonceAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(createAccountInstruction, [payer, nonceAccount]);
+
+        const initializeNonceInstruction = await programClient.methods
+            .initializeNonceAccount({
+                nonceAuthority: originalAuthority,
+            })
+            .accounts({
+                nonceAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(initializeNonceInstruction, [payer]);
+
+        const initializedAccount = ctx.requireEncodedAccount(nonceAccount);
+        expect(initializedAccount).toMatchObject({
+            lamports: BigInt(fundingLamports),
+            owner: programClient.programAddress,
+            executable: false,
+        });
+
+        const authorizeNonceInstruction = await programClient.methods
+            .authorizeNonceAccount({
+                newNonceAuthority: newAuthority,
+            })
+            .accounts({
+                nonceAccount,
+                nonceAuthority: originalAuthority,
+            })
+            .instruction();
+
+        ctx.sendInstruction(authorizeNonceInstruction, [originalAuthority]);
+
+        const authorizedAccount = ctx.requireEncodedAccount(nonceAccount);
+        expect(authorizedAccount).toMatchObject({
+            lamports: BigInt(fundingLamports),
+            owner: programClient.programAddress,
+            executable: false,
+        });
+        expect(authorizedAccount.data.length).toBe(nonceAccountSpace);
+    });
+
+    test('should allow changing authority multiple times', async () => {
+        const payer = ctx.createFundedAccount();
+        const nonceAccount = ctx.createAccount();
+        const firstAuthority = ctx.createFundedAccount();
+        const secondAuthority = ctx.createFundedAccount();
+        const thirdAuthority = ctx.createAccount();
+
+        const nonceAccountSpace = 80;
+        const fundingLamports = 10_000_000;
+
+        const createAccountInstruction = await programClient.methods
+            .createAccount({
+                lamports: fundingLamports,
+                space: nonceAccountSpace,
+                programAddress: programClient.programAddress,
+            })
+            .accounts({
+                payer,
+                newAccount: nonceAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(createAccountInstruction, [payer, nonceAccount]);
+
+        const initializeNonceInstruction = await programClient.methods
+            .initializeNonceAccount({
+                nonceAuthority: firstAuthority,
+            })
+            .accounts({
+                nonceAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(initializeNonceInstruction, [payer]);
+
+        const authorizeToSecondInstruction = await programClient.methods
+            .authorizeNonceAccount({
+                newNonceAuthority: secondAuthority,
+            })
+            .accounts({
+                nonceAccount,
+                nonceAuthority: firstAuthority,
+            })
+            .instruction();
+
+        ctx.sendInstruction(authorizeToSecondInstruction, [firstAuthority]);
+
+        const authorizeToThirdInstruction = await programClient.methods
+            .authorizeNonceAccount({
+                newNonceAuthority: thirdAuthority,
+            })
+            .accounts({
+                nonceAccount,
+                nonceAuthority: secondAuthority,
+            })
+            .instruction();
+
+        ctx.sendInstruction(authorizeToThirdInstruction, [secondAuthority]);
+
+        const finalAccount = ctx.requireEncodedAccount(nonceAccount);
+        expect(finalAccount).toMatchObject({
+            lamports: BigInt(fundingLamports),
+            owner: programClient.programAddress,
+            executable: false,
+        });
+        expect(finalAccount.data.length).toBe(nonceAccountSpace);
+    });
+
+    test('should work when authority transfers to itself (no-op transfer)', async () => {
+        const payer = ctx.createFundedAccount();
+        const nonceAccount = ctx.createAccount();
+        const authority = ctx.createFundedAccount();
+
+        const nonceAccountSpace = 80;
+        const fundingLamports = 10_000_000;
+
+        const createAccountInstruction = await programClient.methods
+            .createAccount({
+                lamports: fundingLamports,
+                space: nonceAccountSpace,
+                programAddress: programClient.programAddress,
+            })
+            .accounts({
+                payer,
+                newAccount: nonceAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(createAccountInstruction, [payer, nonceAccount]);
+
+        const initializeNonceInstruction = await programClient.methods
+            .initializeNonceAccount({
+                nonceAuthority: authority,
+            })
+            .accounts({
+                nonceAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(initializeNonceInstruction, [payer]);
+
+        const authorizeInstruction = await programClient.methods
+            .authorizeNonceAccount({
+                newNonceAuthority: authority,
+            })
+            .accounts({
+                nonceAccount,
+                nonceAuthority: authority,
+            })
+            .instruction();
+
+        ctx.sendInstruction(authorizeInstruction, [authority]);
+
+        const finalAccount = ctx.requireEncodedAccount(nonceAccount);
+        expect(finalAccount).toMatchObject({
+            lamports: BigInt(fundingLamports),
+            owner: programClient.programAddress,
+            executable: false,
+        });
+    });
+});

--- a/packages/dynamic-instructions/tests/system-program/create-account-with-seed.test.ts
+++ b/packages/dynamic-instructions/tests/system-program/create-account-with-seed.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { createTestProgramClient, SvmTestContext } from '../test-utils';
+
+describe('System Program: createAccountWithSeed', () => {
+    const programClient = createTestProgramClient('system-program-idl.json');
+    let ctx: SvmTestContext;
+
+    beforeEach(() => {
+        ctx = new SvmTestContext();
+    });
+
+    test('should create a new account at a seed-derived address', async () => {
+        const payerAccount = ctx.createFundedAccount();
+        const baseAccount = ctx.createFundedAccount();
+
+        const seed = 'vault';
+        const newAccount = await ctx.createAccountWithSeed(baseAccount, seed, programClient.programAddress);
+
+        const accountSpace = 64;
+        const fundingLamports = 5_000_000;
+
+        const createAccountWithSeedInstruction = await programClient.methods
+            .createAccountWithSeed({
+                base: baseAccount,
+                seed,
+                amount: fundingLamports,
+                space: accountSpace,
+                programAddress: programClient.programAddress,
+            })
+            .accounts({
+                payer: payerAccount,
+                newAccount,
+                baseAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(createAccountWithSeedInstruction, [payerAccount, baseAccount]);
+
+        const createdAccount = ctx.requireEncodedAccount(newAccount);
+
+        expect(createdAccount).toMatchObject({
+            lamports: BigInt(fundingLamports),
+            data: new Uint8Array(accountSpace),
+            owner: programClient.programAddress,
+            executable: false,
+        });
+    });
+});

--- a/packages/dynamic-instructions/tests/system-program/create-account.test.ts
+++ b/packages/dynamic-instructions/tests/system-program/create-account.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { createTestProgramClient, SvmTestContext } from '../test-utils';
+
+describe('System Program: createAccount', () => {
+    const programClient = createTestProgramClient('system-program-idl.json');
+    let ctx: SvmTestContext;
+
+    beforeEach(() => {
+        ctx = new SvmTestContext();
+    });
+
+    test('should create a new account with specified space and lamports', async () => {
+        const payerAccount = ctx.createFundedAccount();
+        const newAccountAddress = ctx.createAccount();
+
+        const accountSpace = 165;
+        const fundingLamports = 10_000_000;
+
+        const createAccountInstruction = await programClient.methods
+            .createAccount({
+                lamports: fundingLamports,
+                space: accountSpace,
+                programAddress: programClient.programAddress,
+            })
+            .accounts({
+                payer: payerAccount,
+                newAccount: newAccountAddress,
+            })
+            .instruction();
+
+        ctx.sendInstruction(createAccountInstruction, [payerAccount, newAccountAddress]);
+
+        const createdAccount = ctx.requireEncodedAccount(newAccountAddress);
+
+        expect(createdAccount).toMatchObject({
+            lamports: BigInt(fundingLamports),
+            data: new Uint8Array(accountSpace),
+            owner: programClient.programAddress,
+            executable: false,
+        });
+    });
+});

--- a/packages/dynamic-instructions/tests/system-program/initialize-nonce-account.test.ts
+++ b/packages/dynamic-instructions/tests/system-program/initialize-nonce-account.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { createTestProgramClient, SvmTestContext } from '../test-utils';
+
+describe('System Program: initializeNonceAccount', () => {
+    const programClient = createTestProgramClient('system-program-idl.json');
+    let ctx: SvmTestContext;
+
+    beforeEach(() => {
+        ctx = new SvmTestContext();
+    });
+
+    test('should initialize a nonce account with specified authority', async () => {
+        const payer = ctx.createFundedAccount();
+        const nonceAccount = ctx.createAccount();
+        const nonceAuthority = ctx.createAccount();
+
+        const nonceAccountSpace = 80;
+        const fundingLamports = 10_000_000;
+
+        const createAccountInstruction = await programClient.methods
+            .createAccount({
+                lamports: fundingLamports,
+                space: nonceAccountSpace,
+                programAddress: programClient.programAddress,
+            })
+            .accounts({
+                payer,
+                newAccount: nonceAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(createAccountInstruction, [payer, nonceAccount]);
+
+        const createdAccount = ctx.requireEncodedAccount(nonceAccount);
+        expect(createdAccount.data.length).toBe(nonceAccountSpace);
+
+        const initializeNonceInstruction = await programClient.methods
+            .initializeNonceAccount({
+                nonceAuthority,
+            })
+            .accounts({
+                nonceAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(initializeNonceInstruction, [payer]);
+
+        const initializedAccount = ctx.requireEncodedAccount(nonceAccount);
+
+        expect(initializedAccount).toMatchObject({
+            lamports: BigInt(fundingLamports),
+            owner: programClient.programAddress,
+            executable: false,
+        });
+        expect(initializedAccount.data.length).toBe(nonceAccountSpace);
+        expect(initializedAccount.data.some(byte => byte !== 0)).toBe(true);
+    });
+
+    test('should initialize a nonce account where authority is also the payer', async () => {
+        const payerAndAuthority = ctx.createFundedAccount();
+        const nonceAccount = ctx.createAccount();
+
+        const nonceAccountSpace = 80;
+        const fundingLamports = 5_000_000;
+
+        const createAccountInstruction = await programClient.methods
+            .createAccount({
+                lamports: fundingLamports,
+                space: nonceAccountSpace,
+                programAddress: programClient.programAddress,
+            })
+            .accounts({
+                payer: payerAndAuthority,
+                newAccount: nonceAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(createAccountInstruction, [payerAndAuthority, nonceAccount]);
+
+        const initializeNonceInstruction = await programClient.methods
+            .initializeNonceAccount({
+                nonceAuthority: payerAndAuthority,
+            })
+            .accounts({
+                nonceAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(initializeNonceInstruction, [payerAndAuthority]);
+
+        const initializedAccount = ctx.requireEncodedAccount(nonceAccount);
+
+        expect(initializedAccount).toMatchObject({
+            lamports: BigInt(fundingLamports),
+            owner: programClient.programAddress,
+            executable: false,
+        });
+        expect(initializedAccount.data.length).toBe(nonceAccountSpace);
+    });
+});

--- a/packages/dynamic-instructions/tests/system-program/transfer-sol-with-seed.test.ts
+++ b/packages/dynamic-instructions/tests/system-program/transfer-sol-with-seed.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { createTestProgramClient, SvmTestContext } from '../test-utils';
+
+describe('System Program: transferSolWithSeed', () => {
+    const programClient = createTestProgramClient('system-program-idl.json');
+    let ctx: SvmTestContext;
+
+    beforeEach(() => {
+        ctx = new SvmTestContext();
+    });
+
+    test('should transfer SOL from a seed-derived account to a destination', async () => {
+        const payerAccount = ctx.createFundedAccount();
+        const baseAccount = ctx.createFundedAccount();
+
+        const seed = 'vault';
+        const source = await ctx.createAccountWithSeed(baseAccount, seed, programClient.programAddress);
+
+        const fundingLamports = 10_000_000;
+        const createIx = await programClient.methods
+            .createAccountWithSeed({
+                base: baseAccount,
+                seed,
+                amount: fundingLamports,
+                space: 0,
+                programAddress: programClient.programAddress,
+            })
+            .accounts({
+                payer: payerAccount,
+                newAccount: source,
+                baseAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(createIx, [payerAccount, baseAccount]);
+
+        const destination = ctx.createAccount();
+        const transferAmount = 3_000_000;
+
+        expect(ctx.requireEncodedAccount(source).lamports).toBe(BigInt(fundingLamports));
+        expect(ctx.fetchEncodedAccount(destination)).toBeNull();
+
+        const transferIx = await programClient.methods
+            .transferSolWithSeed({
+                amount: transferAmount,
+                fromSeed: seed,
+                fromOwner: programClient.programAddress,
+            })
+            .accounts({
+                source,
+                baseAccount,
+                destination,
+            })
+            .instruction();
+
+        ctx.sendInstruction(transferIx, [baseAccount]);
+
+        const sourceAfter = ctx.requireEncodedAccount(source);
+        const destinationAfter = ctx.requireEncodedAccount(destination);
+
+        expect(sourceAfter.lamports).toBe(BigInt(fundingLamports) - BigInt(transferAmount));
+        expect(destinationAfter.lamports).toBe(BigInt(transferAmount));
+    });
+});

--- a/packages/dynamic-instructions/tests/system-program/transfer-sol.test.ts
+++ b/packages/dynamic-instructions/tests/system-program/transfer-sol.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { createTestProgramClient, SvmTestContext } from '../test-utils';
+
+describe('System Program: transferSol', () => {
+    const programClient = createTestProgramClient('system-program-idl.json');
+    let ctx: SvmTestContext;
+
+    beforeEach(() => {
+        ctx = new SvmTestContext();
+    });
+
+    test('should transfer SOL from one account to another', async () => {
+        const initialSourceBalance = 3_000_000_000;
+        const source = ctx.createFundedAccount(BigInt(initialSourceBalance));
+        const destination = ctx.createAccount();
+        const transferAmount = 1_000_000_000;
+
+        expect(ctx.fetchEncodedAccount(source)).toMatchObject({
+            lamports: BigInt(initialSourceBalance),
+        });
+        expect(ctx.fetchEncodedAccount(destination)).toBeNull();
+
+        const instruction = await programClient.methods
+            .transferSol({ amount: transferAmount })
+            .accounts({ source, destination })
+            .instruction();
+
+        ctx.sendInstruction(instruction, [source]);
+
+        const sourceAccount = ctx.requireEncodedAccount(source);
+        expect(sourceAccount.lamports).toBeLessThan(BigInt(initialSourceBalance) - BigInt(transferAmount));
+        const destinationAccount = ctx.requireEncodedAccount(destination);
+        expect(destinationAccount.lamports).toBe(BigInt(transferAmount));
+    });
+});

--- a/packages/dynamic-instructions/tests/system-program/upgrade-nonce-account.test.ts
+++ b/packages/dynamic-instructions/tests/system-program/upgrade-nonce-account.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { createTestProgramClient, SvmTestContext } from '../test-utils';
+
+/**
+ *
+ * NOTE: This instruction only works on LEGACY nonce accounts (created before
+ * the version field was added). When we create new nonce accounts with
+ * initializeNonceAccount, they are already in the CURRENT format, so calling
+ * upgradeNonceAccount on them will fail with "InvalidArgument".
+ *
+ * These tests verify that the instruction can be built correctly, but cannot
+ * test the actual upgrade behavior since we cannot easily create legacy nonce
+ * accounts in the test environment.
+ */
+describe('System Program: upgradeNonceAccount', () => {
+    const programClient = createTestProgramClient('system-program-idl.json');
+    let ctx: SvmTestContext;
+
+    beforeEach(() => {
+        ctx = new SvmTestContext();
+    });
+
+    test('smoke: should build upgrade nonce account instruction correctly', async () => {
+        const nonceAccount = ctx.createAccount();
+
+        const upgradeNonceInstruction = await programClient.methods
+            .upgradeNonceAccount()
+            .accounts({
+                nonceAccount,
+            })
+            .instruction();
+
+        expect(upgradeNonceInstruction).toBeDefined();
+        expect(upgradeNonceInstruction.programAddress).toBe(programClient.programAddress);
+        expect(upgradeNonceInstruction.accounts).toBeDefined();
+        expect(upgradeNonceInstruction.data).toBeDefined();
+
+        expect(upgradeNonceInstruction.accounts?.length).toBe(1);
+
+        const nonceAccountMeta = upgradeNonceInstruction.accounts?.[0];
+        expect(nonceAccountMeta?.address).toBe(nonceAccount);
+    });
+});

--- a/packages/dynamic-instructions/tests/system-program/withdraw-nonce-account.test.ts
+++ b/packages/dynamic-instructions/tests/system-program/withdraw-nonce-account.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { createTestProgramClient, SvmTestContext } from '../test-utils';
+
+describe('System Program: withdrawNonceAccount', () => {
+    const programClient = createTestProgramClient('system-program-idl.json');
+    let ctx: SvmTestContext;
+
+    beforeEach(() => {
+        ctx = new SvmTestContext();
+    });
+
+    test('should withdraw lamports from nonce account to recipient', async () => {
+        const payer = ctx.createFundedAccount();
+        const nonceAccount = ctx.createAccount();
+        const nonceAuthority = ctx.createFundedAccount();
+        const recipient = ctx.createAccount();
+
+        const nonceAccountSpace = 80;
+        const fundingLamports = 10_000_000;
+        const withdrawAmount = 2_000_000;
+
+        const createAccountInstruction = await programClient.methods
+            .createAccount({
+                lamports: fundingLamports,
+                space: nonceAccountSpace,
+                programAddress: programClient.programAddress,
+            })
+            .accounts({
+                payer,
+                newAccount: nonceAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(createAccountInstruction, [payer, nonceAccount]);
+
+        const initializeNonceInstruction = await programClient.methods
+            .initializeNonceAccount({
+                nonceAuthority,
+            })
+            .accounts({
+                nonceAccount,
+            })
+            .instruction();
+
+        ctx.sendInstruction(initializeNonceInstruction, [payer]);
+
+        const beforeWithdraw = ctx.requireEncodedAccount(nonceAccount);
+        expect(beforeWithdraw.lamports).toBe(BigInt(fundingLamports));
+
+        const withdrawInstruction = await programClient.methods
+            .withdrawNonceAccount({
+                withdrawAmount,
+            })
+            .accounts({
+                nonceAccount,
+                recipientAccount: recipient,
+                nonceAuthority,
+            })
+            .instruction();
+
+        ctx.sendInstruction(withdrawInstruction, [nonceAuthority]);
+
+        const afterWithdrawNonce = ctx.requireEncodedAccount(nonceAccount);
+        expect(afterWithdrawNonce.lamports).toBe(BigInt(fundingLamports - withdrawAmount));
+
+        const recipientAccount = ctx.requireEncodedAccount(recipient);
+        expect(recipientAccount.lamports).toBe(BigInt(withdrawAmount));
+    });
+});

--- a/packages/dynamic-instructions/tests/test-utils.ts
+++ b/packages/dynamic-instructions/tests/test-utils.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { createProgramClient } from '../src';
+import type { IdlInput, ProgramClient } from '../src';
+
+export function loadIdl(idlFileName: string, baseDir?: string): IdlInput {
+    const basePath = baseDir ?? path.resolve(__dirname, 'idls');
+    const idlPath = path.resolve(basePath, idlFileName);
+    const idlJson: unknown = JSON.parse(readFileSync(idlPath, 'utf8'));
+    if (typeof idlJson !== 'object' || idlJson === null) {
+        throw new Error(`Invalid IDL json: ${idlFileName}`);
+    }
+    return idlJson as IdlInput;
+}
+
+export function createTestProgramClient(idlFileName: string): ProgramClient {
+    const idl = loadIdl(idlFileName);
+    return createProgramClient(idl);
+}
+
+export { SvmTestContext, type EncodedAccount } from './svm-test-context';


### PR DESCRIPTION
## Description

Introduces an SVM-based test harness and a full suite of System Program tests for the dynamic-instructions package.

- **SVM test context (`SvmTestContext`)**: A test context built on LiteSVM that exposes a Solana Kit–style API (Address, Instruction). It manages keypairs and transaction building internally so tests can work declaratively with `createFundedAccount`, `sendInstruction`, `fetchEncodedAccount`, etc., without touching legacy web3.js types.
- **Test utilities**: `test-utils.ts` adds `loadIdl`, `createTestProgramClient`, and re-exports `SvmTestContext` and `EncodedAccount` for use across tests.
- **System Program tests**: 13 test files covering System Program instructions: transfer SOL (plain and with seed), allocate / allocateWithSeed, assign / assignWithSeed, createAccount / createAccountWithSeed, advance/initialize/authorize/withdraw/upgrade nonce account.
- **Instruction encoding**: Validators now handle `sizePrefixTypeNode` (e.g. length-prefixed strings) instead of throwing, and trailing commas are normalized in reducer returns for style consistency.
- **Anchor IDL spec**: `idl.spec.ts` refactored for clarity and to align with the new test setup.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [x] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

N/A — test infrastructure and tests only.

## Testing

- New tests run via Vitest. Execute the test suite in `packages/dynamic-instructions` to verify all System Program tests and the refactored IDL spec pass.
- Each system program test uses `SvmTestContext` to create accounts, build instructions via the program client, send transactions, and assert on balances and account data.

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->
Fixes [HOO-290](https://linear.app/solana-fndn/issue/HOO-290/codama-add-support-for-system-program)

## Checklist

<!-- Verify that you have completed the following before requesting review -->
-   [x] I have added tests that prove my fix/feature works

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

- `SvmTestContext` converts legacy web3.js transactions/instructions internally via `toLegacyTransactionInstruction` so tests stay on Solana Kit types only.
