### PR TITLE
feat: add token program support

### DIFF
--- a/packages/dynamic-instructions/scripts/generate-program-client-types.mts
+++ b/packages/dynamic-instructions/scripts/generate-program-client-types.mts
@@ -50,10 +50,19 @@ interface DefinedTypeNode {
     type: TypeNode;
 }
 
+interface RemainingAccountsNode {
+    kind: string;
+    isOptional?: boolean;
+    isSigner?: boolean | 'either';
+    isWritable?: boolean;
+    value: { kind: string; name: string };
+}
+
 interface InstructionNode {
     name: string;
     arguments: FieldNode[];
     accounts: AccountNode[];
+    remainingAccounts?: RemainingAccountsNode[];
 }
 
 interface IdlRoot {
@@ -137,8 +146,9 @@ export type MethodBuilder<TAccounts> = {
 
         // Build args interface
         const args = ix.arguments.filter(arg => arg.defaultValueStrategy !== 'omitted');
+        const remainingAccountArgs = (ix.remainingAccounts ?? []).filter(ra => ra.value.kind === 'argumentValueNode');
         let argsRef = 'void';
-        if (args.length > 0) {
+        if (args.length > 0 || remainingAccountArgs.length > 0) {
             const argsInterfaceName = `${typeName}Args`;
             output += `export type ${argsInterfaceName} = {\n`;
             for (const arg of args) {
@@ -146,6 +156,10 @@ export type MethodBuilder<TAccounts> = {
                 const isOptional = arg.type.kind === 'optionTypeNode';
                 const sep = isOptional ? '?:' : ':';
                 output += `    ${arg.name}${sep} ${tsType};\n`;
+            }
+            for (const ra of remainingAccountArgs) {
+                const sep = ra.isOptional ? '?:' : ':';
+                output += `    ${ra.value.name}${sep} Address[];\n`;
             }
             output += '};\n\n';
             argsRef = argsInterfaceName;
@@ -166,10 +180,11 @@ export type MethodBuilder<TAccounts> = {
         }
 
         // Generate method type
-        const methodSignature =
-            argsRef === 'void'
-                ? `() => MethodBuilder<${accountsInterfaceName}>`
-                : `(args: ${argsRef}) => MethodBuilder<${accountsInterfaceName}>`;
+        const hasRequiredArgs = args.some(arg => arg.type.kind !== 'optionTypeNode');
+        const hasRequiredRemainingAccounts = remainingAccountArgs.some(ra => !ra.isOptional);
+        const allArgsOptional = !hasRequiredArgs && !hasRequiredRemainingAccounts;
+        const argsParam = argsRef === 'void' ? '' : allArgsOptional ? `args?: ${argsRef}` : `args: ${argsRef}`;
+        const methodSignature = `(${argsParam}) => MethodBuilder<${accountsInterfaceName}>`;
         output += `export type ${typeName}Method = ${methodSignature};\n\n`;
     }
 

--- a/packages/dynamic-instructions/src/features/instruction-encoding/accounts/resolve-account-meta.ts
+++ b/packages/dynamic-instructions/src/features/instruction-encoding/accounts/resolve-account-meta.ts
@@ -96,6 +96,8 @@ function isIxAccountRequired(ixAccountNode: InstructionAccountNode) {
     return !ixAccountNode.isOptional && !ixAccountNode.defaultValue;
 }
 
+// TODO: 'either' is treated as signer — this works for Token Program multisig signers,
+// but may need refinement for programs where 'either' accounts are sometimes non-signers.
 function getRemainingAccountRole(isSigner?: boolean | 'either', isWritable?: boolean): AccountRole {
     const signer = isSigner === true || isSigner === 'either';
     const writable = isWritable === true;

--- a/packages/dynamic-instructions/src/features/instruction-encoding/accounts/resolve-account-meta.ts
+++ b/packages/dynamic-instructions/src/features/instruction-encoding/accounts/resolve-account-meta.ts
@@ -3,8 +3,7 @@ import type { AccountMeta } from '@solana/instructions';
 import { AccountRole } from '@solana/instructions';
 import type { InstructionAccountNode, InstructionNode, RootNode } from 'codama';
 
-import type { AddressInput } from '../../../shared/address';
-import { toAddress } from '../../../shared/address';
+import { isPublicKeyLike, toAddress } from '../../../shared/address';
 import { AccountError } from '../../../shared/errors';
 import type { AccountsInput, ArgumentsInput, ResolutionPath } from '../../../shared/types';
 import { resolveAccountAddress } from './resolve-account-address';
@@ -82,7 +81,13 @@ export async function resolveAccountMeta(
             );
         }
         const role = getRemainingAccountRole(remainingNode.isSigner, remainingNode.isWritable);
-        for (const addr of addresses as AddressInput[]) {
+        for (let i = 0; i < addresses.length; i++) {
+            const addr: unknown = addresses[i];
+            if (typeof addr !== 'string' && !isPublicKeyLike(addr)) {
+                throw new AccountError(
+                    `Remaining account argument "${remainingNode.value.name}[${i}]" must be an address string or PublicKey, got ${typeof addr}`,
+                );
+            }
             accountMetas.push({ address: toAddress(addr), role });
         }
     }

--- a/packages/dynamic-instructions/src/features/instruction-encoding/accounts/resolve-account-meta.ts
+++ b/packages/dynamic-instructions/src/features/instruction-encoding/accounts/resolve-account-meta.ts
@@ -72,7 +72,9 @@ export async function resolveAccountMeta(
     // Resolve remaining accounts from argument values
     // https://github.com/codama-idl/codama/blob/main/packages/nodes/docs/InstructionRemainingAccountsNode.md
     for (const remainingNode of ixNode.remainingAccounts ?? []) {
-        if (remainingNode.value.kind !== 'argumentValueNode') continue;
+        if (remainingNode.value.kind !== 'argumentValueNode') {
+            throw new AccountError(`Unsupported remaining accounts value kind: "${remainingNode.value.kind}"`);
+        }
         const addresses = argumentsInput[remainingNode.value.name];
         if (addresses === undefined) continue;
         if (!Array.isArray(addresses)) {

--- a/packages/dynamic-instructions/src/features/instruction-encoding/accounts/resolve-account-meta.ts
+++ b/packages/dynamic-instructions/src/features/instruction-encoding/accounts/resolve-account-meta.ts
@@ -74,10 +74,15 @@ export async function resolveAccountMeta(
     // https://github.com/codama-idl/codama/blob/main/packages/nodes/docs/InstructionRemainingAccountsNode.md
     for (const remainingNode of ixNode.remainingAccounts ?? []) {
         if (remainingNode.value.kind !== 'argumentValueNode') continue;
-        const addresses = argumentsInput[remainingNode.value.name] as AddressInput[] | undefined;
+        const addresses = argumentsInput[remainingNode.value.name];
         if (addresses === undefined) continue;
+        if (!Array.isArray(addresses)) {
+            throw new AccountError(
+                `Remaining account argument "${remainingNode.value.name}" must be an array of addresses`,
+            );
+        }
         const role = getRemainingAccountRole(remainingNode.isSigner, remainingNode.isWritable);
-        for (const addr of addresses) {
+        for (const addr of addresses as AddressInput[]) {
             accountMetas.push({ address: toAddress(addr), role });
         }
     }

--- a/packages/dynamic-instructions/src/features/instruction-encoding/accounts/resolve-account-meta.ts
+++ b/packages/dynamic-instructions/src/features/instruction-encoding/accounts/resolve-account-meta.ts
@@ -3,6 +3,7 @@ import type { AccountMeta } from '@solana/instructions';
 import { AccountRole } from '@solana/instructions';
 import type { InstructionAccountNode, InstructionNode, RootNode } from 'codama';
 
+import type { AddressInput } from '../../../shared/address';
 import { toAddress } from '../../../shared/address';
 import { AccountError } from '../../../shared/errors';
 import type { AccountsInput, ArgumentsInput, ResolutionPath } from '../../../shared/types';
@@ -61,26 +62,42 @@ export async function resolveAccountMeta(
         }),
     );
 
-    // FIXME: Handle remaining accounts:
-    // Can be provided via argument, e.g argumentValueNode("signers"), multisig signers in Token Program
+    const accountMetas: AccountMeta[] = resolvedAccounts
+        // omitted optional accounts
+        .filter((acc): acc is ResolvedAccountWithAddress => acc.address !== null)
+        .map(acc => ({
+            address: acc.address,
+            role: acc.role,
+        }));
+
+    // Resolve remaining accounts from argument values
     // https://github.com/codama-idl/codama/blob/main/packages/nodes/docs/InstructionRemainingAccountsNode.md
-    return (
-        resolvedAccounts
-            // omitted optional accounts
-            .filter((acc): acc is ResolvedAccountWithAddress => acc.address !== null)
-            .map(acc => {
-                return {
-                    address: acc.address,
-                    role: acc.role,
-                };
-            })
-    );
+    for (const remainingNode of ixNode.remainingAccounts ?? []) {
+        if (remainingNode.value.kind !== 'argumentValueNode') continue;
+        const addresses = argumentsInput[remainingNode.value.name] as AddressInput[] | undefined;
+        if (addresses === undefined) continue;
+        const role = getRemainingAccountRole(remainingNode.isSigner, remainingNode.isWritable);
+        for (const addr of addresses) {
+            accountMetas.push({ address: toAddress(addr), role });
+        }
+    }
+
+    return accountMetas;
 }
 
 // Optional accounts can be omitted
 // Accounts with default values can be omitted, as they can be resolved from default value
 function isIxAccountRequired(ixAccountNode: InstructionAccountNode) {
     return !ixAccountNode.isOptional && !ixAccountNode.defaultValue;
+}
+
+function getRemainingAccountRole(isSigner?: boolean | 'either', isWritable?: boolean): AccountRole {
+    const signer = isSigner === true || isSigner === 'either';
+    const writable = isWritable === true;
+    if (writable && signer) return AccountRole.WRITABLE_SIGNER;
+    if (writable) return AccountRole.WRITABLE;
+    if (signer) return AccountRole.READONLY_SIGNER;
+    return AccountRole.READONLY;
 }
 
 function getAccountRole(acc: InstructionAccountNode): AccountRole {

--- a/packages/dynamic-instructions/src/features/instruction-encoding/arguments.ts
+++ b/packages/dynamic-instructions/src/features/instruction-encoding/arguments.ts
@@ -69,6 +69,12 @@ export function validateArgumentsInput(root: RootNode, ixNode: InstructionNode, 
 
     if (!requiredArguments.length) return;
 
+    // Strip remaining account argument names so superstruct's object() doesn't reject them as extra keys
+    const remainingAccountArgNames = getRemainingAccountArgNames(ixNode);
+    const filteredInput = remainingAccountArgNames.length
+        ? Object.fromEntries(Object.entries(argumentsInput).filter(([key]) => !remainingAccountArgNames.includes(key)))
+        : argumentsInput;
+
     const ArgumentsInputValidator = createIxArgumentsValidator(
         ixNode.name,
         requiredArguments,
@@ -76,7 +82,7 @@ export function validateArgumentsInput(root: RootNode, ixNode: InstructionNode, 
     );
 
     try {
-        assert(argumentsInput, ArgumentsInputValidator);
+        assert(filteredInput, ArgumentsInputValidator);
     } catch (error) {
         const { failures } = error as StructError;
         const message = failures().map(failure => {
@@ -103,4 +109,10 @@ function validateOmittedArguments(ixNode: InstructionNode, argumentsInput: Argum
 
 function isIxArgumentOmitted(node: InstructionArgumentNode) {
     return node.defaultValueStrategy === 'omitted';
+}
+
+function getRemainingAccountArgNames(ixNode: InstructionNode): string[] {
+    return (ixNode.remainingAccounts ?? [])
+        .filter(node => node.value.kind === 'argumentValueNode')
+        .map(node => node.value.name);
 }

--- a/packages/dynamic-instructions/tests/features/instruction-encoding/arguments.test.ts
+++ b/packages/dynamic-instructions/tests/features/instruction-encoding/arguments.test.ts
@@ -1,3 +1,4 @@
+import { address } from '@solana/addresses';
 import { getU32Encoder, getU64Encoder } from '@solana/codecs';
 import { getInitializeInstructionDataDecoder } from '@solana-program/program-metadata';
 import type { InstructionNode, RootNode } from 'codama';
@@ -132,5 +133,53 @@ describe('Instruction encoding: encodeInstructionArguments', () => {
         const encoded = encodeInstructionArguments(root, ix, {});
         const discriminator = 6;
         expect(encoded).toEqual(new Uint8Array([discriminator]));
+    });
+});
+
+describe('Instruction validation: remaining account arguments', () => {
+    const ADDR_1 = address('11111111111111111111111111111111');
+    const ADDR_2 = address('22222222222222222222222222222222222222222222');
+
+    test('should not reject remaining account args as extra keys', () => {
+        // initializeMultisig has remainingAccounts referencing "signers" argumentValueNode
+        // superstruct's object() rejects unknown keys, so "signers" must be stripped before validation
+        const root = loadRoot('token-idl.json');
+        const ix = getInstruction(root, 'initializeMultisig');
+
+        expect(() => validateArgumentsInput(root, ix, { m: 2, signers: [ADDR_1, ADDR_2] })).not.toThrow();
+    });
+
+    test('should still validate regular arguments when remaining account args are present', () => {
+        const root = loadRoot('token-idl.json');
+        const ix = getInstruction(root, 'initializeMultisig');
+
+        // m is a required number argument — passing a string should fail validation
+        expect(() => validateArgumentsInput(root, ix, { m: 'invalid', signers: [ADDR_1] })).toThrow(ValidationError);
+    });
+
+    test('should not reject optional remaining account args when omitted', () => {
+        // transfer has optional multiSigners remaining accounts
+        const root = loadRoot('token-idl.json');
+        const ix = getInstruction(root, 'transfer');
+
+        expect(() => validateArgumentsInput(root, ix, { amount: 100 })).not.toThrow();
+    });
+
+    test('should not reject optional remaining account args when provided', () => {
+        const root = loadRoot('token-idl.json');
+        const ix = getInstruction(root, 'transfer');
+
+        expect(() => validateArgumentsInput(root, ix, { amount: 100, multiSigners: [ADDR_1] })).not.toThrow();
+    });
+
+    test('should not encode remaining account args as instruction data', () => {
+        const root = loadRoot('token-idl.json');
+        const ix = getInstruction(root, 'initializeMultisig');
+
+        const withSigners = encodeInstructionArguments(root, ix, { m: 2, signers: [ADDR_1, ADDR_2] });
+        const withoutSigners = encodeInstructionArguments(root, ix, { m: 2 });
+
+        // Remaining account args should not affect encoded data
+        expect(withSigners).toEqual(withoutSigners);
     });
 });

--- a/packages/dynamic-instructions/tests/features/instruction-encoding/arguments.test.ts
+++ b/packages/dynamic-instructions/tests/features/instruction-encoding/arguments.test.ts
@@ -2,7 +2,6 @@ import { address } from '@solana/addresses';
 import { getU32Encoder, getU64Encoder } from '@solana/codecs';
 import { getInitializeInstructionDataDecoder } from '@solana-program/program-metadata';
 import type { InstructionNode, RootNode } from 'codama';
-import { createFromJson } from 'codama';
 import { describe, expect, test } from 'vitest';
 
 import {
@@ -11,13 +10,7 @@ import {
 } from '../../../src/features/instruction-encoding/arguments';
 import { concatBytes, getCodecFromBytesEncoding } from '../../../src/shared/bytes-encoding';
 import { ArgumentError, ValidationError } from '../../../src/shared/errors';
-import { loadIdl } from '../../test-utils';
-
-function loadRoot(idlFileName: string): RootNode {
-    const idl = loadIdl(idlFileName);
-    const json = JSON.stringify(idl);
-    return createFromJson(json).getRoot();
-}
+import { loadRoot } from '../../test-utils';
 
 function getInstruction(root: RootNode, name: string): InstructionNode {
     const ix = root.program.instructions.find(i => i.name === name);

--- a/packages/dynamic-instructions/tests/features/instruction-encoding/resolve-account-meta.test.ts
+++ b/packages/dynamic-instructions/tests/features/instruction-encoding/resolve-account-meta.test.ts
@@ -7,18 +7,6 @@ import { describe, expect, test } from 'vitest';
 import { resolveAccountMeta } from '../../../src/features/instruction-encoding/accounts/resolve-account-meta';
 import { loadIdl } from '../../test-utils';
 
-function loadRoot(idlFileName: string): RootNode {
-    const idl = loadIdl(idlFileName);
-    const json = JSON.stringify(idl);
-    return createFromJson(json).getRoot();
-}
-
-function getInstruction(root: RootNode, name: string): InstructionNode {
-    const ix = root.program.instructions.find(i => i.name === name);
-    if (!ix) throw new Error(`Instruction ${name} not found`);
-    return ix;
-}
-
 const ADDR_1 = address('11111111111111111111111111111111');
 const ADDR_2 = address('22222222222222222222222222222222222222222222');
 const ADDR_3 = address('33333333333333333333333333333333333333333333');
@@ -117,6 +105,24 @@ describe('resolveAccountMeta: remaining accounts', () => {
         ).rejects.toThrow('Remaining account argument "signers" must be an array of addresses');
     });
 
+    test('should throw when remaining account value kind is not argumentValueNode', async () => {
+        const root = loadRoot('token-idl.json');
+        const ix = getInstruction(root, 'initializeMultisig');
+
+        // Replace the argumentValueNode with an unsupported value kind
+        const remainingAccount = ix.remainingAccounts?.[0];
+        const modifiedRemainingAccount = Object.assign({}, remainingAccount, {
+            value: { kind: 'resolverValueNode', name: 'someResolver' },
+        }) as typeof remainingAccount;
+        const modifiedIx: InstructionNode = Object.assign({}, ix, {
+            remainingAccounts: [modifiedRemainingAccount],
+        });
+
+        await expect(resolveAccountMeta(root, modifiedIx, { m: 2 }, { multisig: MULTISIG_ADDR })).rejects.toThrow(
+            'Unsupported remaining accounts value kind: "resolverValueNode"',
+        );
+    });
+
     test('should throw when remaining account array contains invalid element types', async () => {
         const root = loadRoot('token-idl.json');
         const ix = getInstruction(root, 'initializeMultisig');
@@ -126,3 +132,15 @@ describe('resolveAccountMeta: remaining accounts', () => {
         ).rejects.toThrow('Remaining account argument "signers[1]" must be an address string or PublicKey, got number');
     });
 });
+
+function loadRoot(idlFileName: string): RootNode {
+    const idl = loadIdl(idlFileName);
+    const json = JSON.stringify(idl);
+    return createFromJson(json).getRoot();
+}
+
+function getInstruction(root: RootNode, name: string): InstructionNode {
+    const ix = root.program.instructions.find(i => i.name === name);
+    if (!ix) throw new Error(`Instruction ${name} not found`);
+    return ix;
+}

--- a/packages/dynamic-instructions/tests/features/instruction-encoding/resolve-account-meta.test.ts
+++ b/packages/dynamic-instructions/tests/features/instruction-encoding/resolve-account-meta.test.ts
@@ -107,4 +107,13 @@ describe('resolveAccountMeta: remaining accounts', () => {
         // Should only have regular accounts (mint + rent sysvar)
         expect(result).toHaveLength(2);
     });
+
+    test('should throw when remaining account argument is not an array', async () => {
+        const root = loadRoot('token-idl.json');
+        const ix = getInstruction(root, 'initializeMultisig');
+
+        await expect(
+            resolveAccountMeta(root, ix, { m: 2, signers: ADDR_1 }, { multisig: MULTISIG_ADDR }),
+        ).rejects.toThrow('Remaining account argument "signers" must be an array of addresses');
+    });
 });

--- a/packages/dynamic-instructions/tests/features/instruction-encoding/resolve-account-meta.test.ts
+++ b/packages/dynamic-instructions/tests/features/instruction-encoding/resolve-account-meta.test.ts
@@ -116,4 +116,13 @@ describe('resolveAccountMeta: remaining accounts', () => {
             resolveAccountMeta(root, ix, { m: 2, signers: ADDR_1 }, { multisig: MULTISIG_ADDR }),
         ).rejects.toThrow('Remaining account argument "signers" must be an array of addresses');
     });
+
+    test('should throw when remaining account array contains invalid element types', async () => {
+        const root = loadRoot('token-idl.json');
+        const ix = getInstruction(root, 'initializeMultisig');
+
+        await expect(
+            resolveAccountMeta(root, ix, { m: 2, signers: [ADDR_1, 123] }, { multisig: MULTISIG_ADDR }),
+        ).rejects.toThrow('Remaining account argument "signers[1]" must be an address string or PublicKey, got number');
+    });
 });

--- a/packages/dynamic-instructions/tests/features/instruction-encoding/resolve-account-meta.test.ts
+++ b/packages/dynamic-instructions/tests/features/instruction-encoding/resolve-account-meta.test.ts
@@ -1,0 +1,110 @@
+import { address } from '@solana/addresses';
+import { AccountRole } from '@solana/instructions';
+import type { InstructionNode, RootNode } from 'codama';
+import { createFromJson } from 'codama';
+import { describe, expect, test } from 'vitest';
+
+import { resolveAccountMeta } from '../../../src/features/instruction-encoding/accounts/resolve-account-meta';
+import { loadIdl } from '../../test-utils';
+
+function loadRoot(idlFileName: string): RootNode {
+    const idl = loadIdl(idlFileName);
+    const json = JSON.stringify(idl);
+    return createFromJson(json).getRoot();
+}
+
+function getInstruction(root: RootNode, name: string): InstructionNode {
+    const ix = root.program.instructions.find(i => i.name === name);
+    if (!ix) throw new Error(`Instruction ${name} not found`);
+    return ix;
+}
+
+const ADDR_1 = address('11111111111111111111111111111111');
+const ADDR_2 = address('22222222222222222222222222222222222222222222');
+const ADDR_3 = address('33333333333333333333333333333333333333333333');
+const MULTISIG_ADDR = address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+
+describe('resolveAccountMeta: remaining accounts', () => {
+    test('should append remaining accounts from argumentsInput', async () => {
+        // initializeMultisig has remainingAccounts: [{ value: argumentValueNode("signers") }]
+        // It has 2 regular accounts: multisig (user-provided) + rent (default: SysvarRent)
+        const root = loadRoot('token-idl.json');
+        const ix = getInstruction(root, 'initializeMultisig');
+
+        const result = await resolveAccountMeta(
+            root,
+            ix,
+            { m: 2, signers: [ADDR_1, ADDR_2, ADDR_3] },
+            { multisig: MULTISIG_ADDR },
+        );
+
+        // 2 regular accounts (multisig + rent) + 3 remaining accounts
+        expect(result).toHaveLength(5);
+        const remainingAccounts = result.slice(2);
+        expect(remainingAccounts[0]).toEqual({ address: ADDR_1, role: AccountRole.READONLY });
+        expect(remainingAccounts[1]).toEqual({ address: ADDR_2, role: AccountRole.READONLY });
+        expect(remainingAccounts[2]).toEqual({ address: ADDR_3, role: AccountRole.READONLY });
+    });
+
+    test('should use READONLY_SIGNER role when isSigner is true', async () => {
+        // transfer has remainingAccounts: [{ value: argumentValueNode("multiSigners"), isOptional: true, isSigner: true }]
+        // It has 3 regular accounts: source, destination, authority (default: identity)
+        const root = loadRoot('token-idl.json');
+        const ix = getInstruction(root, 'transfer');
+
+        const result = await resolveAccountMeta(
+            root,
+            ix,
+            { amount: 100, multiSigners: [ADDR_1, ADDR_2] },
+            { authority: ADDR_3, destination: MULTISIG_ADDR, source: ADDR_3 },
+        );
+
+        // 3 regular accounts + 2 remaining accounts
+        const remainingAccounts = result.slice(3);
+        expect(remainingAccounts).toHaveLength(2);
+        expect(remainingAccounts[0]).toEqual({ address: ADDR_1, role: AccountRole.READONLY_SIGNER });
+        expect(remainingAccounts[1]).toEqual({ address: ADDR_2, role: AccountRole.READONLY_SIGNER });
+    });
+
+    test('should skip optional remaining accounts when not provided', async () => {
+        // transfer's multiSigners is optional — omitting it should produce no extra accounts
+        const root = loadRoot('token-idl.json');
+        const ix = getInstruction(root, 'transfer');
+
+        const result = await resolveAccountMeta(
+            root,
+            ix,
+            { amount: 100 },
+            { authority: ADDR_1, destination: MULTISIG_ADDR, source: ADDR_3 },
+        );
+
+        // Only 3 regular accounts, no remaining
+        expect(result).toHaveLength(3);
+    });
+
+    test('should append empty array as no remaining accounts', async () => {
+        const root = loadRoot('token-idl.json');
+        const ix = getInstruction(root, 'initializeMultisig');
+
+        const result = await resolveAccountMeta(root, ix, { m: 1, signers: [] }, { multisig: MULTISIG_ADDR });
+
+        // 2 regular accounts (multisig + rent), no remaining
+        expect(result).toHaveLength(2);
+    });
+
+    test('should return no remaining accounts when instruction has none defined', async () => {
+        // initializeMint has no remainingAccounts
+        const root = loadRoot('token-idl.json');
+        const ix = getInstruction(root, 'initializeMint');
+
+        const result = await resolveAccountMeta(
+            root,
+            ix,
+            { decimals: 9, freezeAuthority: null, mintAuthority: ADDR_1 },
+            { mint: MULTISIG_ADDR },
+        );
+
+        // Should only have regular accounts (mint + rent sysvar)
+        expect(result).toHaveLength(2);
+    });
+});

--- a/packages/dynamic-instructions/tests/features/instruction-encoding/resolve-account-meta.test.ts
+++ b/packages/dynamic-instructions/tests/features/instruction-encoding/resolve-account-meta.test.ts
@@ -1,11 +1,10 @@
 import { address } from '@solana/addresses';
 import { AccountRole } from '@solana/instructions';
 import type { InstructionNode, RootNode } from 'codama';
-import { createFromJson } from 'codama';
 import { describe, expect, test } from 'vitest';
 
 import { resolveAccountMeta } from '../../../src/features/instruction-encoding/accounts/resolve-account-meta';
-import { loadIdl } from '../../test-utils';
+import { loadRoot } from '../../test-utils';
 
 const ADDR_1 = address('11111111111111111111111111111111');
 const ADDR_2 = address('22222222222222222222222222222222222222222222');
@@ -132,12 +131,6 @@ describe('resolveAccountMeta: remaining accounts', () => {
         ).rejects.toThrow('Remaining account argument "signers[1]" must be an address string or PublicKey, got number');
     });
 });
-
-function loadRoot(idlFileName: string): RootNode {
-    const idl = loadIdl(idlFileName);
-    const json = JSON.stringify(idl);
-    return createFromJson(json).getRoot();
-}
 
 function getInstruction(root: RootNode, name: string): InstructionNode {
     const ix = root.program.instructions.find(i => i.name === name);

--- a/packages/dynamic-instructions/tests/svm-test-context.ts
+++ b/packages/dynamic-instructions/tests/svm-test-context.ts
@@ -1,7 +1,7 @@
 import { type Address, address } from '@solana/addresses';
 import type { Instruction } from '@solana/instructions';
 import * as web3 from '@solana/web3.js';
-import { FailedTransactionMetadata, LiteSVM } from 'litesvm';
+import { FailedTransactionMetadata, LiteSVM, type TransactionMetadata } from 'litesvm';
 
 import { toLegacyTransactionInstruction } from '../src';
 
@@ -174,64 +174,13 @@ export class SvmTestContext {
     }
 
     /** Builds, signs, and sends a transaction with a single instruction. Signers must be context-owned. */
-    sendInstruction(instruction: Instruction, signers: Address[]): void {
-        if (signers.length === 0) {
-            throw new Error('At least one signer is required');
-        }
-
-        const keypairs = signers.map(addr => {
-            const keypair = this.accounts.get(addr);
-            if (!keypair) {
-                throw new Error(`Signer ${addr} not found in context`);
-            }
-            return keypair;
-        });
-
-        const legacyIx = toLegacyTransactionInstruction(instruction);
-        const transaction = new web3.Transaction().add(legacyIx);
-        const feePayer = keypairs[0];
-        if (!feePayer) throw new Error('No signers');
-        transaction.feePayer = feePayer.publicKey;
-        transaction.recentBlockhash = this.svm.latestBlockhash();
-        transaction.sign(...keypairs);
-
-        const result = this.svm.sendTransaction(transaction);
-        if (result instanceof FailedTransactionMetadata) {
-            console.error('Transaction failed, logs:\n', result.meta().prettyLogs());
-            throw new Error(`Transaction failed: ${result.toString()}`);
-        }
+    sendInstruction(instruction: Instruction, signers: Address[]): TransactionMetadata {
+        return this.buildAndSend([instruction], signers);
     }
 
     /** Builds, signs, and sends a transaction with multiple instructions. Signers must be context-owned. */
-    sendInstructions(instructions: Instruction[], signers: Address[]): void {
-        if (signers.length === 0) {
-            throw new Error('At least one signer is required');
-        }
-
-        const keypairs = signers.map(addr => {
-            const keypair = this.accounts.get(addr);
-            if (!keypair) {
-                throw new Error(`Signer ${addr} not found in context`);
-            }
-            return keypair;
-        });
-
-        const transaction = new web3.Transaction();
-        for (const instruction of instructions) {
-            const legacyIx = toLegacyTransactionInstruction(instruction);
-            transaction.add(legacyIx);
-        }
-
-        const feePayer = keypairs[0];
-        if (!feePayer) throw new Error('No signers');
-        transaction.feePayer = feePayer.publicKey;
-        transaction.recentBlockhash = this.svm.latestBlockhash();
-        transaction.sign(...keypairs);
-
-        const result = this.svm.sendTransaction(transaction);
-        if (result instanceof FailedTransactionMetadata) {
-            throw new Error(`Transaction failed: ${result.toString()}`);
-        }
+    sendInstructions(instructions: Instruction[], signers: Address[]): TransactionMetadata {
+        return this.buildAndSend(instructions, signers);
     }
 
     /** Warps the SVM to the specified slot. */
@@ -261,5 +210,37 @@ export class SvmTestContext {
     /** Returns the underlying LiteSVM instance for direct use when needed. Consider using the public methods instead. */
     getSvm(): LiteSVM {
         return this.svm;
+    }
+
+    private buildAndSend(instructions: Instruction[], signers: Address[]): TransactionMetadata {
+        if (signers.length === 0) {
+            throw new Error('At least one signer is required');
+        }
+
+        const keypairs = signers.map(addr => {
+            const keypair = this.accounts.get(addr);
+            if (!keypair) {
+                throw new Error(`Signer ${addr} not found in context`);
+            }
+            return keypair;
+        });
+
+        const transaction = new web3.Transaction();
+        for (const instruction of instructions) {
+            transaction.add(toLegacyTransactionInstruction(instruction));
+        }
+
+        const feePayer = keypairs[0];
+        if (!feePayer) throw new Error('No signers');
+        transaction.feePayer = feePayer.publicKey;
+        transaction.recentBlockhash = this.svm.latestBlockhash();
+        transaction.sign(...keypairs);
+
+        const result = this.svm.sendTransaction(transaction);
+        if (result instanceof FailedTransactionMetadata) {
+            console.error('Transaction failed, logs:\n', result.meta().prettyLogs());
+            throw new Error(`Transaction failed: ${result.toString()}`);
+        }
+        return result;
     }
 }

--- a/packages/dynamic-instructions/tests/test-utils.ts
+++ b/packages/dynamic-instructions/tests/test-utils.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
+import { createFromJson, type RootNode } from 'codama';
+
 import type { IdlInput, ProgramClient } from '../src';
 import { createProgramClient } from '../src';
 
@@ -25,6 +27,12 @@ export function loadIdl(idlFileName: string, baseDir?: string): IdlInput {
 export function createTestProgramClient<T = ProgramClient>(idlFileName: string): T {
     const idl = loadIdl(idlFileName);
     return createProgramClient<T>(idl);
+}
+
+export function loadRoot(idlFileName: string): RootNode {
+    const idl = loadIdl(idlFileName);
+    const json = JSON.stringify(idl);
+    return createFromJson(json).getRoot();
 }
 
 export { SvmTestContext, type EncodedAccount } from './svm-test-context';

--- a/packages/dynamic-instructions/tests/token/amount-to-ui-amount.test.ts
+++ b/packages/dynamic-instructions/tests/token/amount-to-ui-amount.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { createMint, tokenClient } from './token-test-utils';
+
+describe('Token Program: amountToUiAmount', () => {
+    test('should convert a token amount to its UI representation', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+
+        await createMint(ctx, payer, mintAccount, payer);
+
+        const ix = await tokenClient.methods
+            .amountToUiAmount({ amount: 1_000_000_000 })
+            .accounts({ mint: mintAccount })
+            .instruction();
+
+        const meta = ctx.sendInstruction(ix, [payer]);
+        const returnData = meta.returnData();
+        const uiAmount = new TextDecoder().decode(returnData.data());
+        expect(uiAmount).toBe('1');
+    });
+});

--- a/packages/dynamic-instructions/tests/token/approve-checked.test.ts
+++ b/packages/dynamic-instructions/tests/token/approve-checked.test.ts
@@ -1,0 +1,35 @@
+import { getTokenDecoder } from '@solana-program/token';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { createMint, createTokenAccount, tokenClient } from './token-test-utils';
+
+describe('Token Program: approveChecked', () => {
+    test('should approve a delegate with mint and decimals verification', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+        const sourceAccount = ctx.createAccount();
+        const delegate = ctx.createAccount();
+
+        await createMint(ctx, payer, mintAccount, payer);
+        await createTokenAccount(ctx, payer, sourceAccount, mintAccount, payer);
+
+        const mintIx = await tokenClient.methods
+            .mintTo({ amount: 1_000_000 })
+            .accounts({ mint: mintAccount, mintAuthority: payer, token: sourceAccount })
+            .instruction();
+        ctx.sendInstruction(mintIx, [payer]);
+
+        const ix = await tokenClient.methods
+            .approveChecked({ amount: 500_000, decimals: 9 })
+            .accounts({ delegate, mint: mintAccount, owner: payer, source: sourceAccount })
+            .instruction();
+        ctx.sendInstruction(ix, [payer]);
+
+        const decoder = getTokenDecoder();
+        const sourceData = decoder.decode(ctx.requireEncodedAccount(sourceAccount).data);
+        expect(sourceData.delegate).toStrictEqual({ __option: 'Some', value: delegate });
+        expect(sourceData.delegatedAmount).toBe(500_000n);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/approve.test.ts
+++ b/packages/dynamic-instructions/tests/token/approve.test.ts
@@ -1,0 +1,35 @@
+import { getTokenDecoder } from '@solana-program/token';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { createMint, createTokenAccount, tokenClient } from './token-test-utils';
+
+describe('Token Program: approve', () => {
+    test('should approve a delegate for a token account', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+        const sourceAccount = ctx.createAccount();
+        const delegate = ctx.createAccount();
+
+        await createMint(ctx, payer, mintAccount, payer);
+        await createTokenAccount(ctx, payer, sourceAccount, mintAccount, payer);
+
+        const mintIx = await tokenClient.methods
+            .mintTo({ amount: 1_000_000 })
+            .accounts({ mint: mintAccount, mintAuthority: payer, token: sourceAccount })
+            .instruction();
+        ctx.sendInstruction(mintIx, [payer]);
+
+        const ix = await tokenClient.methods
+            .approve({ amount: 500_000 })
+            .accounts({ delegate, owner: payer, source: sourceAccount })
+            .instruction();
+        ctx.sendInstruction(ix, [payer]);
+
+        const decoder = getTokenDecoder();
+        const sourceData = decoder.decode(ctx.requireEncodedAccount(sourceAccount).data);
+        expect(sourceData.delegate).toStrictEqual({ __option: 'Some', value: delegate });
+        expect(sourceData.delegatedAmount).toBe(500_000n);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/burn-checked.test.ts
+++ b/packages/dynamic-instructions/tests/token/burn-checked.test.ts
@@ -1,0 +1,33 @@
+import { getTokenDecoder } from '@solana-program/token';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { createMint, createTokenAccount, tokenClient } from './token-test-utils';
+
+describe('Token Program: burnChecked', () => {
+    test('should burn tokens with decimals verification', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+        const tokenAccount = ctx.createAccount();
+
+        await createMint(ctx, payer, mintAccount, payer);
+        await createTokenAccount(ctx, payer, tokenAccount, mintAccount, payer);
+
+        const mintIx = await tokenClient.methods
+            .mintTo({ amount: 1_000_000 })
+            .accounts({ mint: mintAccount, mintAuthority: payer, token: tokenAccount })
+            .instruction();
+        ctx.sendInstruction(mintIx, [payer]);
+
+        const ix = await tokenClient.methods
+            .burnChecked({ amount: 400_000, decimals: 9 })
+            .accounts({ account: tokenAccount, authority: payer, mint: mintAccount })
+            .instruction();
+        ctx.sendInstruction(ix, [payer]);
+
+        const decoder = getTokenDecoder();
+        const tokenData = decoder.decode(ctx.requireEncodedAccount(tokenAccount).data);
+        expect(tokenData.amount).toBe(600_000n);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/burn.test.ts
+++ b/packages/dynamic-instructions/tests/token/burn.test.ts
@@ -1,7 +1,7 @@
 import { getMintDecoder, getTokenDecoder } from '@solana-program/token';
 import { describe, expect, test } from 'vitest';
 
-import { SvmTestContext } from '../svm-test-context';
+import { SvmTestContext } from '../test-utils';
 import { createMint, createTokenAccount, tokenClient } from './token-test-utils';
 
 describe('Token Program: burn', () => {

--- a/packages/dynamic-instructions/tests/token/burn.test.ts
+++ b/packages/dynamic-instructions/tests/token/burn.test.ts
@@ -1,0 +1,39 @@
+import { getMintDecoder, getTokenDecoder } from '@solana-program/token';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../svm-test-context';
+import { createMint, createTokenAccount, tokenClient } from './token-test-utils';
+
+describe('Token Program: burn', () => {
+    test('should burn tokens from a token account', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+        const tokenAccount = ctx.createAccount();
+
+        await createMint(ctx, payer, mintAccount, payer);
+        await createTokenAccount(ctx, payer, tokenAccount, mintAccount, payer);
+
+        // Mint tokens first.
+        const mintIx = await tokenClient.methods
+            .mintTo({ amount: 1_000_000 })
+            .accounts({ mint: mintAccount, mintAuthority: payer, token: tokenAccount })
+            .instruction();
+        ctx.sendInstruction(mintIx, [payer]);
+
+        // Burn tokens.
+        const burnIx = await tokenClient.methods
+            .burn({ amount: 400_000 })
+            .accounts({ account: tokenAccount, authority: payer, mint: mintAccount })
+            .instruction();
+        ctx.sendInstruction(burnIx, [payer]);
+
+        // Verify token account balance decreased.
+        const tokenData = getTokenDecoder().decode(ctx.requireEncodedAccount(tokenAccount).data);
+        expect(tokenData.amount).toBe(600_000n);
+
+        // Verify mint supply decreased.
+        const mintData = getMintDecoder().decode(ctx.requireEncodedAccount(mintAccount).data);
+        expect(mintData.supply).toBe(600_000n);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/close-account.test.ts
+++ b/packages/dynamic-instructions/tests/token/close-account.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { createMint, createTokenAccount, tokenClient } from './token-test-utils';
+
+describe('Token Program: closeAccount', () => {
+    test('should close a token account and transfer lamports to destination', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+        const tokenAccount = ctx.createAccount();
+        const owner = ctx.createFundedAccount();
+
+        await createMint(ctx, payer, mintAccount, payer);
+        await createTokenAccount(ctx, payer, tokenAccount, mintAccount, owner);
+
+        const destBalanceBefore = ctx.getBalanceOrZero(owner);
+
+        const ix = await tokenClient.methods
+            .closeAccount()
+            .accounts({ account: tokenAccount, destination: owner, owner })
+            .instruction();
+        ctx.sendInstruction(ix, [owner]);
+
+        expect(ctx.fetchEncodedAccount(tokenAccount)).toBeNull();
+        expect(ctx.getBalanceOrZero(owner)).toBeGreaterThan(destBalanceBefore);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/freeze-account.test.ts
+++ b/packages/dynamic-instructions/tests/token/freeze-account.test.ts
@@ -1,0 +1,29 @@
+import { AccountState, getTokenDecoder } from '@solana-program/token';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { createMint, createTokenAccount, tokenClient } from './token-test-utils';
+
+describe('Token Program: freezeAccount', () => {
+    test('should freeze a token account', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+        const tokenAccount = ctx.createAccount();
+        const freezeAuthority = ctx.createFundedAccount();
+
+        await createMint(ctx, payer, mintAccount, payer, freezeAuthority);
+        await createTokenAccount(ctx, payer, tokenAccount, mintAccount, payer);
+
+        const freezeIx = await tokenClient.methods
+            .freezeAccount()
+            .accounts({ account: tokenAccount, mint: mintAccount, owner: freezeAuthority })
+            .instruction();
+
+        ctx.sendInstruction(freezeIx, [freezeAuthority]);
+
+        const account = ctx.requireEncodedAccount(tokenAccount);
+        const tokenData = getTokenDecoder().decode(account.data);
+        expect(tokenData.state).toBe(AccountState.Frozen);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/get-account-data-size.test.ts
+++ b/packages/dynamic-instructions/tests/token/get-account-data-size.test.ts
@@ -1,0 +1,21 @@
+import { getU64Decoder } from '@solana/codecs';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { createMint, SPL_TOKEN_ACCOUNT_SIZE, tokenClient } from './token-test-utils';
+
+describe('Token Program: getAccountDataSize', () => {
+    test('should return the required account size for a given mint', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+
+        await createMint(ctx, payer, mintAccount, payer);
+
+        const ix = await tokenClient.methods.getAccountDataSize().accounts({ mint: mintAccount }).instruction();
+
+        const meta = ctx.sendInstruction(ix, [payer]);
+        const size = getU64Decoder().decode(meta.returnData().data());
+        expect(size).toBe(BigInt(SPL_TOKEN_ACCOUNT_SIZE));
+    });
+});

--- a/packages/dynamic-instructions/tests/token/initialize-account.test.ts
+++ b/packages/dynamic-instructions/tests/token/initialize-account.test.ts
@@ -1,7 +1,8 @@
+import { AccountState, getTokenDecoder } from '@solana-program/token';
 import { describe, expect, test } from 'vitest';
 
 import { SvmTestContext } from '../test-utils';
-import { createMint, createTokenAccount, SPL_TOKEN_ACCOUNT_SIZE, tokenClient } from './token-test-utils';
+import { createMint, createTokenAccount } from './token-test-utils';
 
 describe('Token Program: initializeAccount', () => {
     test('should initialize a token account', async () => {
@@ -14,8 +15,10 @@ describe('Token Program: initializeAccount', () => {
         await createMint(ctx, payer, mintAccount, payer);
         await createTokenAccount(ctx, payer, tokenAccount, mintAccount, owner);
 
-        const encodedAccount = ctx.requireEncodedAccount(tokenAccount);
-        expect(encodedAccount.owner).toBe(tokenClient.programAddress);
-        expect(encodedAccount.data.length).toBe(SPL_TOKEN_ACCOUNT_SIZE);
+        const tokenData = getTokenDecoder().decode(ctx.requireEncodedAccount(tokenAccount).data);
+        expect(tokenData.mint).toBe(mintAccount);
+        expect(tokenData.owner).toBe(owner);
+        expect(tokenData.amount).toBe(0n);
+        expect(tokenData.state).toBe(AccountState.Initialized);
     });
 });

--- a/packages/dynamic-instructions/tests/token/initialize-account.test.ts
+++ b/packages/dynamic-instructions/tests/token/initialize-account.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { createMint, createTokenAccount, tokenClient } from './token-test-utils';
+import { SPL_TOKEN_ACCOUNT_SIZE } from './token-test-utils';
+
+describe('Token Program: initializeAccount', () => {
+    test('should initialize a token account', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+        const tokenAccount = ctx.createAccount();
+        const owner = ctx.createAccount();
+
+        await createMint(ctx, payer, mintAccount, payer);
+        await createTokenAccount(ctx, payer, tokenAccount, mintAccount, owner);
+
+        const encodedAccount = ctx.requireEncodedAccount(tokenAccount);
+        expect(encodedAccount.owner).toBe(tokenClient.programAddress);
+        expect(encodedAccount.data.length).toBe(SPL_TOKEN_ACCOUNT_SIZE);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/initialize-account.test.ts
+++ b/packages/dynamic-instructions/tests/token/initialize-account.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import { SvmTestContext } from '../test-utils';
-import { createMint, createTokenAccount, tokenClient } from './token-test-utils';
-import { SPL_TOKEN_ACCOUNT_SIZE } from './token-test-utils';
+import { createMint, createTokenAccount, SPL_TOKEN_ACCOUNT_SIZE, tokenClient } from './token-test-utils';
 
 describe('Token Program: initializeAccount', () => {
     test('should initialize a token account', async () => {

--- a/packages/dynamic-instructions/tests/token/initialize-account2.test.ts
+++ b/packages/dynamic-instructions/tests/token/initialize-account2.test.ts
@@ -1,5 +1,4 @@
-import { getTokenDecoder } from '@solana-program/token';
-import { AccountState } from '@solana-program/token';
+import { AccountState, getTokenDecoder } from '@solana-program/token';
 import { describe, expect, test } from 'vitest';
 
 import { SvmTestContext } from '../test-utils';

--- a/packages/dynamic-instructions/tests/token/initialize-account2.test.ts
+++ b/packages/dynamic-instructions/tests/token/initialize-account2.test.ts
@@ -1,0 +1,41 @@
+import { getTokenDecoder } from '@solana-program/token';
+import { AccountState } from '@solana-program/token';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { createMint, SPL_TOKEN_ACCOUNT_SIZE, systemClient, tokenClient } from './token-test-utils';
+
+describe('Token Program: initializeAccount2', () => {
+    test('should initialize a token account with owner passed as instruction data', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+        const tokenAccount = ctx.createAccount();
+        const owner = ctx.createAccount();
+
+        await createMint(ctx, payer, mintAccount, payer);
+
+        const lamports = ctx.getMinimumBalanceForRentExemption(BigInt(SPL_TOKEN_ACCOUNT_SIZE));
+        const createAccountIx = await systemClient.methods
+            .createAccount({
+                lamports,
+                programAddress: tokenClient.programAddress,
+                space: SPL_TOKEN_ACCOUNT_SIZE,
+            })
+            .accounts({ newAccount: tokenAccount, payer })
+            .instruction();
+
+        const initAccountIx = await tokenClient.methods
+            .initializeAccount2({ owner })
+            .accounts({ account: tokenAccount, mint: mintAccount })
+            .instruction();
+
+        ctx.sendInstructions([createAccountIx, initAccountIx], [payer, tokenAccount]);
+
+        const decoder = getTokenDecoder();
+        const tokenData = decoder.decode(ctx.requireEncodedAccount(tokenAccount).data);
+        expect(tokenData.mint).toBe(mintAccount);
+        expect(tokenData.owner).toBe(owner);
+        expect(tokenData.state).toBe(AccountState.Initialized);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/initialize-account3.test.ts
+++ b/packages/dynamic-instructions/tests/token/initialize-account3.test.ts
@@ -1,0 +1,40 @@
+import { AccountState, getTokenDecoder } from '@solana-program/token';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { createMint, SPL_TOKEN_ACCOUNT_SIZE, systemClient, tokenClient } from './token-test-utils';
+
+describe('Token Program: initializeAccount3', () => {
+    test('should initialize a token account without requiring the Rent sysvar', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+        const tokenAccount = ctx.createAccount();
+        const owner = ctx.createAccount();
+
+        await createMint(ctx, payer, mintAccount, payer);
+
+        const lamports = ctx.getMinimumBalanceForRentExemption(BigInt(SPL_TOKEN_ACCOUNT_SIZE));
+        const createAccountIx = await systemClient.methods
+            .createAccount({
+                lamports,
+                programAddress: tokenClient.programAddress,
+                space: SPL_TOKEN_ACCOUNT_SIZE,
+            })
+            .accounts({ newAccount: tokenAccount, payer })
+            .instruction();
+
+        const initAccountIx = await tokenClient.methods
+            .initializeAccount3({ owner })
+            .accounts({ account: tokenAccount, mint: mintAccount })
+            .instruction();
+
+        ctx.sendInstructions([createAccountIx, initAccountIx], [payer, tokenAccount]);
+
+        const decoder = getTokenDecoder();
+        const tokenData = decoder.decode(ctx.requireEncodedAccount(tokenAccount).data);
+        expect(tokenData.mint).toBe(mintAccount);
+        expect(tokenData.owner).toBe(owner);
+        expect(tokenData.state).toBe(AccountState.Initialized);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/initialize-immutable-owner.test.ts
+++ b/packages/dynamic-instructions/tests/token/initialize-immutable-owner.test.ts
@@ -1,0 +1,44 @@
+import { getTokenDecoder } from '@solana-program/token';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../svm-test-context';
+import { createMint, SPL_TOKEN_ACCOUNT_SIZE, systemClient, tokenClient } from './token-test-utils';
+
+describe('Token Program: initializeImmutableOwner', () => {
+    test('should initialize immutable owner on a token account before initializeAccount', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+        const tokenAccount = ctx.createAccount();
+
+        await createMint(ctx, payer, mintAccount, payer);
+
+        const rent = ctx.getMinimumBalanceForRentExemption(BigInt(SPL_TOKEN_ACCOUNT_SIZE));
+
+        const createAccountIx = await systemClient.methods
+            .createAccount({
+                lamports: rent,
+                programAddress: tokenClient.programAddress,
+                space: SPL_TOKEN_ACCOUNT_SIZE,
+            })
+            .accounts({ newAccount: tokenAccount, payer })
+            .instruction();
+
+        const initImmutableOwnerIx = await tokenClient.methods
+            .initializeImmutableOwner()
+            .accounts({ account: tokenAccount })
+            .instruction();
+
+        const initAccountIx = await tokenClient.methods
+            .initializeAccount()
+            .accounts({ account: tokenAccount, mint: mintAccount, owner: payer })
+            .instruction();
+
+        ctx.sendInstructions([createAccountIx, initImmutableOwnerIx, initAccountIx], [payer, tokenAccount]);
+
+        const account = ctx.requireEncodedAccount(tokenAccount);
+        const tokenData = getTokenDecoder().decode(account.data);
+        expect(tokenData.mint).toBe(mintAccount);
+        expect(tokenData.owner).toBe(payer);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/initialize-immutable-owner.test.ts
+++ b/packages/dynamic-instructions/tests/token/initialize-immutable-owner.test.ts
@@ -1,7 +1,7 @@
 import { getTokenDecoder } from '@solana-program/token';
 import { describe, expect, test } from 'vitest';
 
-import { SvmTestContext } from '../svm-test-context';
+import { SvmTestContext } from '../test-utils';
 import { createMint, SPL_TOKEN_ACCOUNT_SIZE, systemClient, tokenClient } from './token-test-utils';
 
 describe('Token Program: initializeImmutableOwner', () => {

--- a/packages/dynamic-instructions/tests/token/initialize-mint.test.ts
+++ b/packages/dynamic-instructions/tests/token/initialize-mint.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { systemClient, tokenClient } from './token-test-utils';
+
+describe('Token Program: initializeMint', () => {
+    test('should initialize a mint with default freeze authority (None)', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+
+        const mintSpace = 82;
+        const mintRent = ctx.getMinimumBalanceForRentExemption(BigInt(mintSpace));
+
+        const createAccountIx = await systemClient.methods
+            .createAccount({
+                lamports: mintRent,
+                programAddress: tokenClient.programAddress,
+                space: mintSpace,
+            })
+            .accounts({
+                newAccount: mintAccount,
+                payer,
+            })
+            .instruction();
+
+        const initMintIx = await tokenClient.methods
+            .initializeMint({ decimals: 9, mintAuthority: payer })
+            .accounts({ mint: mintAccount })
+            .instruction();
+
+        ctx.sendInstructions([createAccountIx, initMintIx], [payer, mintAccount]);
+
+        const encodedAccount = ctx.requireEncodedAccount(mintAccount);
+        expect(encodedAccount.owner).toBe(tokenClient.programAddress);
+        expect(encodedAccount.data.length).toBe(mintSpace);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/initialize-mint.test.ts
+++ b/packages/dynamic-instructions/tests/token/initialize-mint.test.ts
@@ -1,3 +1,4 @@
+import { getMintDecoder } from '@solana-program/token';
 import { describe, expect, test } from 'vitest';
 
 import { SvmTestContext } from '../test-utils';
@@ -30,8 +31,10 @@ describe('Token Program: initializeMint', () => {
 
         ctx.sendInstructions([createAccountIx, initMintIx], [payer, mintAccount]);
 
-        const encodedAccount = ctx.requireEncodedAccount(mintAccount);
-        expect(encodedAccount.owner).toBe(tokenClient.programAddress);
-        expect(encodedAccount.data.length).toBe(SPL_TOKEN_MINT_SIZE);
+        const mintData = getMintDecoder().decode(ctx.requireEncodedAccount(mintAccount).data);
+        expect(mintData.mintAuthority).toEqual({ __option: 'Some', value: payer });
+        expect(mintData.decimals).toBe(9);
+        expect(mintData.supply).toBe(0n);
+        expect(mintData.freezeAuthority).toEqual({ __option: 'None' });
     });
 });

--- a/packages/dynamic-instructions/tests/token/initialize-mint.test.ts
+++ b/packages/dynamic-instructions/tests/token/initialize-mint.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import { SvmTestContext } from '../test-utils';
-import { systemClient, tokenClient } from './token-test-utils';
+import { SPL_TOKEN_MINT_SIZE, systemClient, tokenClient } from './token-test-utils';
 
 describe('Token Program: initializeMint', () => {
     test('should initialize a mint with default freeze authority (None)', async () => {
@@ -9,14 +9,13 @@ describe('Token Program: initializeMint', () => {
         const payer = ctx.createFundedAccount();
         const mintAccount = ctx.createAccount();
 
-        const mintSpace = 82;
-        const mintRent = ctx.getMinimumBalanceForRentExemption(BigInt(mintSpace));
+        const mintRent = ctx.getMinimumBalanceForRentExemption(BigInt(SPL_TOKEN_MINT_SIZE));
 
         const createAccountIx = await systemClient.methods
             .createAccount({
                 lamports: mintRent,
                 programAddress: tokenClient.programAddress,
-                space: mintSpace,
+                space: SPL_TOKEN_MINT_SIZE,
             })
             .accounts({
                 newAccount: mintAccount,
@@ -33,6 +32,6 @@ describe('Token Program: initializeMint', () => {
 
         const encodedAccount = ctx.requireEncodedAccount(mintAccount);
         expect(encodedAccount.owner).toBe(tokenClient.programAddress);
-        expect(encodedAccount.data.length).toBe(mintSpace);
+        expect(encodedAccount.data.length).toBe(SPL_TOKEN_MINT_SIZE);
     });
 });

--- a/packages/dynamic-instructions/tests/token/initialize-mint2.test.ts
+++ b/packages/dynamic-instructions/tests/token/initialize-mint2.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import { SvmTestContext } from '../test-utils';
-import { systemClient, tokenClient } from './token-test-utils';
+import { SPL_TOKEN_MINT_SIZE, systemClient, tokenClient } from './token-test-utils';
 
 describe('Token Program: initializeMint2', () => {
     test('should initialize a mint without requiring the Rent sysvar', async () => {
@@ -9,14 +9,13 @@ describe('Token Program: initializeMint2', () => {
         const payer = ctx.createFundedAccount();
         const mintAccount = ctx.createAccount();
 
-        const mintSpace = 82;
-        const mintRent = ctx.getMinimumBalanceForRentExemption(BigInt(mintSpace));
+        const mintRent = ctx.getMinimumBalanceForRentExemption(BigInt(SPL_TOKEN_MINT_SIZE));
 
         const createAccountIx = await systemClient.methods
             .createAccount({
                 lamports: mintRent,
                 programAddress: tokenClient.programAddress,
-                space: mintSpace,
+                space: SPL_TOKEN_MINT_SIZE,
             })
             .accounts({
                 newAccount: mintAccount,
@@ -33,6 +32,6 @@ describe('Token Program: initializeMint2', () => {
 
         const encodedAccount = ctx.requireEncodedAccount(mintAccount);
         expect(encodedAccount.owner).toBe(tokenClient.programAddress);
-        expect(encodedAccount.data.length).toBe(mintSpace);
+        expect(encodedAccount.data.length).toBe(SPL_TOKEN_MINT_SIZE);
     });
 });

--- a/packages/dynamic-instructions/tests/token/initialize-mint2.test.ts
+++ b/packages/dynamic-instructions/tests/token/initialize-mint2.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { systemClient, tokenClient } from './token-test-utils';
+
+describe('Token Program: initializeMint2', () => {
+    test('should initialize a mint without requiring the Rent sysvar', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+
+        const mintSpace = 82;
+        const mintRent = ctx.getMinimumBalanceForRentExemption(BigInt(mintSpace));
+
+        const createAccountIx = await systemClient.methods
+            .createAccount({
+                lamports: mintRent,
+                programAddress: tokenClient.programAddress,
+                space: mintSpace,
+            })
+            .accounts({
+                newAccount: mintAccount,
+                payer,
+            })
+            .instruction();
+
+        const initMintIx = await tokenClient.methods
+            .initializeMint2({ decimals: 9, mintAuthority: payer })
+            .accounts({ mint: mintAccount })
+            .instruction();
+
+        ctx.sendInstructions([createAccountIx, initMintIx], [payer, mintAccount]);
+
+        const encodedAccount = ctx.requireEncodedAccount(mintAccount);
+        expect(encodedAccount.owner).toBe(tokenClient.programAddress);
+        expect(encodedAccount.data.length).toBe(mintSpace);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/initialize-mint2.test.ts
+++ b/packages/dynamic-instructions/tests/token/initialize-mint2.test.ts
@@ -1,3 +1,4 @@
+import { getMintDecoder } from '@solana-program/token';
 import { describe, expect, test } from 'vitest';
 
 import { SvmTestContext } from '../test-utils';
@@ -8,6 +9,7 @@ describe('Token Program: initializeMint2', () => {
         const ctx = new SvmTestContext({ defaultPrograms: true });
         const payer = ctx.createFundedAccount();
         const mintAccount = ctx.createAccount();
+        const freezeAuthority = ctx.createAccount();
 
         const mintRent = ctx.getMinimumBalanceForRentExemption(BigInt(SPL_TOKEN_MINT_SIZE));
 
@@ -24,14 +26,16 @@ describe('Token Program: initializeMint2', () => {
             .instruction();
 
         const initMintIx = await tokenClient.methods
-            .initializeMint2({ decimals: 9, mintAuthority: payer })
+            .initializeMint2({ decimals: 6, freezeAuthority, mintAuthority: payer })
             .accounts({ mint: mintAccount })
             .instruction();
 
         ctx.sendInstructions([createAccountIx, initMintIx], [payer, mintAccount]);
 
-        const encodedAccount = ctx.requireEncodedAccount(mintAccount);
-        expect(encodedAccount.owner).toBe(tokenClient.programAddress);
-        expect(encodedAccount.data.length).toBe(SPL_TOKEN_MINT_SIZE);
+        const mintData = getMintDecoder().decode(ctx.requireEncodedAccount(mintAccount).data);
+        expect(mintData.mintAuthority).toEqual({ __option: 'Some', value: payer });
+        expect(mintData.decimals).toBe(6);
+        expect(mintData.supply).toBe(0n);
+        expect(mintData.freezeAuthority).toEqual({ __option: 'Some', value: freezeAuthority });
     });
 });

--- a/packages/dynamic-instructions/tests/token/initialize-multisig.test.ts
+++ b/packages/dynamic-instructions/tests/token/initialize-multisig.test.ts
@@ -1,0 +1,43 @@
+import { getMultisigDecoder } from '@solana-program/token';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { systemClient, tokenClient } from './token-test-utils';
+
+const SPL_TOKEN_MULTISIG_SIZE = 355;
+
+describe('Token Program: initializeMultisig', () => {
+    test('should initialize a multisig account with 2-of-3 signers', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const multisigAccount = ctx.createAccount();
+
+        const signer1 = ctx.createAccount();
+        const signer2 = ctx.createAccount();
+        const signer3 = ctx.createAccount();
+
+        const lamports = ctx.getMinimumBalanceForRentExemption(BigInt(SPL_TOKEN_MULTISIG_SIZE));
+        const createAccountIx = await systemClient.methods
+            .createAccount({
+                lamports,
+                programAddress: tokenClient.programAddress,
+                space: SPL_TOKEN_MULTISIG_SIZE,
+            })
+            .accounts({ newAccount: multisigAccount, payer })
+            .instruction();
+
+        const initMultisigIx = await tokenClient.methods
+            .initializeMultisig({ m: 2, signers: [signer1, signer2, signer3] })
+            .accounts({ multisig: multisigAccount })
+            .instruction();
+
+        ctx.sendInstructions([createAccountIx, initMultisigIx], [payer, multisigAccount, signer1, signer2, signer3]);
+
+        const decoder = getMultisigDecoder();
+        const multisigData = decoder.decode(ctx.requireEncodedAccount(multisigAccount).data);
+        expect(multisigData.m).toBe(2);
+        expect(multisigData.n).toBe(3);
+        expect(multisigData.isInitialized).toBe(true);
+        expect(multisigData.signers.slice(0, 3)).toStrictEqual([signer1, signer2, signer3]);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/initialize-multisig.test.ts
+++ b/packages/dynamic-instructions/tests/token/initialize-multisig.test.ts
@@ -2,9 +2,7 @@ import { getMultisigDecoder } from '@solana-program/token';
 import { describe, expect, test } from 'vitest';
 
 import { SvmTestContext } from '../test-utils';
-import { systemClient, tokenClient } from './token-test-utils';
-
-const SPL_TOKEN_MULTISIG_SIZE = 355;
+import { SPL_TOKEN_MULTISIG_SIZE, systemClient, tokenClient } from './token-test-utils';
 
 describe('Token Program: initializeMultisig', () => {
     test('should initialize a multisig account with 2-of-3 signers', async () => {

--- a/packages/dynamic-instructions/tests/token/initialize-multisig2.test.ts
+++ b/packages/dynamic-instructions/tests/token/initialize-multisig2.test.ts
@@ -2,9 +2,7 @@ import { getMultisigDecoder } from '@solana-program/token';
 import { describe, expect, test } from 'vitest';
 
 import { SvmTestContext } from '../test-utils';
-import { systemClient, tokenClient } from './token-test-utils';
-
-const SPL_TOKEN_MULTISIG_SIZE = 355;
+import { SPL_TOKEN_MULTISIG_SIZE, systemClient, tokenClient } from './token-test-utils';
 
 describe('Token Program: initializeMultisig2', () => {
     test('should initialize a multisig account without requiring the Rent sysvar', async () => {

--- a/packages/dynamic-instructions/tests/token/initialize-multisig2.test.ts
+++ b/packages/dynamic-instructions/tests/token/initialize-multisig2.test.ts
@@ -1,0 +1,43 @@
+import { getMultisigDecoder } from '@solana-program/token';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { systemClient, tokenClient } from './token-test-utils';
+
+const SPL_TOKEN_MULTISIG_SIZE = 355;
+
+describe('Token Program: initializeMultisig2', () => {
+    test('should initialize a multisig account without requiring the Rent sysvar', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const multisigAccount = ctx.createAccount();
+
+        const signer1 = ctx.createAccount();
+        const signer2 = ctx.createAccount();
+        const signer3 = ctx.createAccount();
+
+        const lamports = ctx.getMinimumBalanceForRentExemption(BigInt(SPL_TOKEN_MULTISIG_SIZE));
+        const createAccountIx = await systemClient.methods
+            .createAccount({
+                lamports,
+                programAddress: tokenClient.programAddress,
+                space: SPL_TOKEN_MULTISIG_SIZE,
+            })
+            .accounts({ newAccount: multisigAccount, payer })
+            .instruction();
+
+        const initMultisigIx = await tokenClient.methods
+            .initializeMultisig2({ m: 2, signers: [signer1, signer2, signer3] })
+            .accounts({ multisig: multisigAccount })
+            .instruction();
+
+        ctx.sendInstructions([createAccountIx, initMultisigIx], [payer, multisigAccount, signer1, signer2, signer3]);
+
+        const decoder = getMultisigDecoder();
+        const multisigData = decoder.decode(ctx.requireEncodedAccount(multisigAccount).data);
+        expect(multisigData.m).toBe(2);
+        expect(multisigData.n).toBe(3);
+        expect(multisigData.isInitialized).toBe(true);
+        expect(multisigData.signers.slice(0, 3)).toStrictEqual([signer1, signer2, signer3]);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/mint-to-checked.test.ts
+++ b/packages/dynamic-instructions/tests/token/mint-to-checked.test.ts
@@ -1,0 +1,27 @@
+import { getTokenDecoder } from '@solana-program/token';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { createMint, createTokenAccount, tokenClient } from './token-test-utils';
+
+describe('Token Program: mintToChecked', () => {
+    test('should mint tokens with decimals verification', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+        const tokenAccount = ctx.createAccount();
+
+        await createMint(ctx, payer, mintAccount, payer);
+        await createTokenAccount(ctx, payer, tokenAccount, mintAccount, payer);
+
+        const ix = await tokenClient.methods
+            .mintToChecked({ amount: 1_000_000, decimals: 9 })
+            .accounts({ mint: mintAccount, mintAuthority: payer, token: tokenAccount })
+            .instruction();
+        ctx.sendInstruction(ix, [payer]);
+
+        const decoder = getTokenDecoder();
+        const tokenData = decoder.decode(ctx.requireEncodedAccount(tokenAccount).data);
+        expect(tokenData.amount).toBe(1_000_000n);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/mint-to.test.ts
+++ b/packages/dynamic-instructions/tests/token/mint-to.test.ts
@@ -1,0 +1,28 @@
+import { getTokenDecoder } from '@solana-program/token';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { createMint, createTokenAccount, tokenClient } from './token-test-utils';
+
+describe('Token Program: mintTo', () => {
+    test('should mint tokens to a token account', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+        const tokenAccount = ctx.createAccount();
+
+        await createMint(ctx, payer, mintAccount, payer);
+        await createTokenAccount(ctx, payer, tokenAccount, mintAccount, payer);
+
+        const ix = await tokenClient.methods
+            .mintTo({ amount: 1_000_000 })
+            .accounts({ mint: mintAccount, mintAuthority: payer, token: tokenAccount })
+            .instruction();
+
+        ctx.sendInstruction(ix, [payer]);
+
+        const account = ctx.requireEncodedAccount(tokenAccount);
+        const tokenData = getTokenDecoder().decode(account.data);
+        expect(tokenData.amount).toBe(1_000_000n);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/revoke.test.ts
+++ b/packages/dynamic-instructions/tests/token/revoke.test.ts
@@ -1,0 +1,38 @@
+import { getTokenDecoder } from '@solana-program/token';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { createMint, createTokenAccount, tokenClient } from './token-test-utils';
+
+describe('Token Program: revoke', () => {
+    test('should revoke a delegate from a token account', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+        const sourceAccount = ctx.createAccount();
+        const delegate = ctx.createAccount();
+
+        await createMint(ctx, payer, mintAccount, payer);
+        await createTokenAccount(ctx, payer, sourceAccount, mintAccount, payer);
+
+        const mintIx = await tokenClient.methods
+            .mintTo({ amount: 1_000_000 })
+            .accounts({ mint: mintAccount, mintAuthority: payer, token: sourceAccount })
+            .instruction();
+        ctx.sendInstruction(mintIx, [payer]);
+
+        const approveIx = await tokenClient.methods
+            .approve({ amount: 500_000 })
+            .accounts({ delegate, owner: payer, source: sourceAccount })
+            .instruction();
+        ctx.sendInstruction(approveIx, [payer]);
+
+        const ix = await tokenClient.methods.revoke().accounts({ owner: payer, source: sourceAccount }).instruction();
+        ctx.sendInstruction(ix, [payer]);
+
+        const decoder = getTokenDecoder();
+        const sourceData = decoder.decode(ctx.requireEncodedAccount(sourceAccount).data);
+        expect(sourceData.delegate).toStrictEqual({ __option: 'None' });
+        expect(sourceData.delegatedAmount).toBe(0n);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/set-authority.test.ts
+++ b/packages/dynamic-instructions/tests/token/set-authority.test.ts
@@ -1,0 +1,26 @@
+import { getMintDecoder } from '@solana-program/token';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { createMint, tokenClient } from './token-test-utils';
+
+describe('Token Program: setAuthority', () => {
+    test('should change the mint authority to a new address', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+        const newAuthority = ctx.createAccount();
+
+        await createMint(ctx, payer, mintAccount, payer);
+
+        const ix = await tokenClient.methods
+            .setAuthority({ authorityType: 'mintTokens', newAuthority })
+            .accounts({ owned: mintAccount, owner: payer })
+            .instruction();
+        ctx.sendInstruction(ix, [payer]);
+
+        const decoder = getMintDecoder();
+        const mintData = decoder.decode(ctx.requireEncodedAccount(mintAccount).data);
+        expect(mintData.mintAuthority).toStrictEqual({ __option: 'Some', value: newAuthority });
+    });
+});

--- a/packages/dynamic-instructions/tests/token/sync-native.test.ts
+++ b/packages/dynamic-instructions/tests/token/sync-native.test.ts
@@ -1,0 +1,54 @@
+import { address } from '@solana/addresses';
+import { getTokenDecoder } from '@solana-program/token';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { SPL_TOKEN_ACCOUNT_SIZE, systemClient, tokenClient } from './token-test-utils';
+
+const NATIVE_MINT = address('So11111111111111111111111111111111111111112');
+
+describe('Token Program: syncNative', () => {
+    test('should sync a wrapped SOL account amount with its lamport balance', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const wrappedSolAccount = ctx.createAccount();
+
+        // Create and initialize a wrapped SOL token account.
+        const lamports = ctx.getMinimumBalanceForRentExemption(BigInt(SPL_TOKEN_ACCOUNT_SIZE));
+        const createAccountIx = await systemClient.methods
+            .createAccount({
+                lamports,
+                programAddress: tokenClient.programAddress,
+                space: SPL_TOKEN_ACCOUNT_SIZE,
+            })
+            .accounts({ newAccount: wrappedSolAccount, payer })
+            .instruction();
+
+        const initAccountIx = await tokenClient.methods
+            .initializeAccount()
+            .accounts({ account: wrappedSolAccount, mint: NATIVE_MINT, owner: payer })
+            .instruction();
+
+        ctx.sendInstructions([createAccountIx, initAccountIx], [payer, wrappedSolAccount]);
+
+        // Transfer additional SOL to the wrapped account via system program.
+        const transferAmount = 1_000_000_000n;
+        const transferIx = await systemClient.methods
+            .transferSol({ amount: transferAmount })
+            .accounts({ destination: wrappedSolAccount, source: payer })
+            .instruction();
+        ctx.sendInstruction(transferIx, [payer]);
+
+        // Token amount is still 0 before sync.
+        const decoder = getTokenDecoder();
+        const beforeSync = decoder.decode(ctx.requireEncodedAccount(wrappedSolAccount).data);
+        expect(beforeSync.amount).toBe(0n);
+
+        // Sync native to update the token amount.
+        const syncIx = await tokenClient.methods.syncNative().accounts({ account: wrappedSolAccount }).instruction();
+        ctx.sendInstruction(syncIx, [payer]);
+
+        const afterSync = decoder.decode(ctx.requireEncodedAccount(wrappedSolAccount).data);
+        expect(afterSync.amount).toBe(transferAmount);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/thaw-account.test.ts
+++ b/packages/dynamic-instructions/tests/token/thaw-account.test.ts
@@ -1,0 +1,36 @@
+import { AccountState, getTokenDecoder } from '@solana-program/token';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { createMint, createTokenAccount, tokenClient } from './token-test-utils';
+
+describe('Token Program: thawAccount', () => {
+    test('should thaw a frozen account', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+        const tokenAccount = ctx.createAccount();
+        const freezeAuthority = ctx.createFundedAccount();
+
+        await createMint(ctx, payer, mintAccount, payer, freezeAuthority);
+        await createTokenAccount(ctx, payer, tokenAccount, mintAccount, payer);
+
+        const freezeIx = await tokenClient.methods
+            .freezeAccount()
+            .accounts({ account: tokenAccount, mint: mintAccount, owner: freezeAuthority })
+            .instruction();
+
+        ctx.sendInstruction(freezeIx, [freezeAuthority]);
+
+        const thawIx = await tokenClient.methods
+            .thawAccount()
+            .accounts({ account: tokenAccount, mint: mintAccount, owner: freezeAuthority })
+            .instruction();
+
+        ctx.sendInstruction(thawIx, [freezeAuthority]);
+
+        const account = ctx.requireEncodedAccount(tokenAccount);
+        const tokenData = getTokenDecoder().decode(account.data);
+        expect(tokenData.state).toBe(AccountState.Initialized);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/token-test-utils.ts
+++ b/packages/dynamic-instructions/tests/token/token-test-utils.ts
@@ -9,6 +9,7 @@ export const systemClient = createTestProgramClient<SystemProgramClient>('system
 
 export const SPL_TOKEN_MINT_SIZE = 82;
 export const SPL_TOKEN_ACCOUNT_SIZE = 165;
+export const SPL_TOKEN_MULTISIG_SIZE = 355;
 
 export async function createMint(
     ctx: SvmTestContext,

--- a/packages/dynamic-instructions/tests/token/token-test-utils.ts
+++ b/packages/dynamic-instructions/tests/token/token-test-utils.ts
@@ -1,0 +1,53 @@
+import type { Address } from '@solana/addresses';
+
+import type { SystemProgramClient } from '../generated/system-program-idl-types';
+import type { TokenProgramClient } from '../generated/token-idl-types';
+import { createTestProgramClient, SvmTestContext } from '../test-utils';
+
+export const tokenClient = createTestProgramClient<TokenProgramClient>('token-idl.json');
+export const systemClient = createTestProgramClient<SystemProgramClient>('system-program-idl.json');
+
+export const SPL_TOKEN_MINT_SIZE = 82;
+export const SPL_TOKEN_ACCOUNT_SIZE = 165;
+
+export async function createMint(
+    ctx: SvmTestContext,
+    payer: Address,
+    mint: Address,
+    mintAuthority: Address,
+    freezeAuthority?: Address,
+): Promise<void> {
+    const lamports = ctx.getMinimumBalanceForRentExemption(BigInt(SPL_TOKEN_MINT_SIZE));
+    const createMintAccountIx = await systemClient.methods
+        .createAccount({ lamports, programAddress: tokenClient.programAddress, space: SPL_TOKEN_MINT_SIZE })
+        .accounts({ newAccount: mint, payer })
+        .instruction();
+    ctx.sendInstruction(createMintAccountIx, [payer, mint]);
+
+    const initializeMintIx = await tokenClient.methods
+        .initializeMint({ decimals: 9, freezeAuthority: freezeAuthority ?? null, mintAuthority })
+        .accounts({ mint })
+        .instruction();
+    ctx.sendInstruction(initializeMintIx, [payer]);
+}
+
+export async function createTokenAccount(
+    ctx: SvmTestContext,
+    payer: Address,
+    account: Address,
+    mint: Address,
+    owner: Address,
+): Promise<void> {
+    const lamports = ctx.getMinimumBalanceForRentExemption(BigInt(SPL_TOKEN_ACCOUNT_SIZE));
+    const createAccountIx = await systemClient.methods
+        .createAccount({ lamports, programAddress: tokenClient.programAddress, space: SPL_TOKEN_ACCOUNT_SIZE })
+        .accounts({ newAccount: account, payer })
+        .instruction();
+
+    const initAccountIx = await tokenClient.methods
+        .initializeAccount()
+        .accounts({ account, mint, owner })
+        .instruction();
+
+    ctx.sendInstructions([createAccountIx, initAccountIx], [payer, account]);
+}

--- a/packages/dynamic-instructions/tests/token/transfer-checked.test.ts
+++ b/packages/dynamic-instructions/tests/token/transfer-checked.test.ts
@@ -1,0 +1,37 @@
+import { getTokenDecoder } from '@solana-program/token';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { createMint, createTokenAccount, tokenClient } from './token-test-utils';
+
+describe('Token Program: transferChecked', () => {
+    test('should transfer tokens with mint and decimal verification', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+        const sourceAccount = ctx.createAccount();
+        const destinationAccount = ctx.createAccount();
+
+        await createMint(ctx, payer, mintAccount, payer);
+        await createTokenAccount(ctx, payer, sourceAccount, mintAccount, payer);
+        await createTokenAccount(ctx, payer, destinationAccount, mintAccount, payer);
+
+        const mintIx = await tokenClient.methods
+            .mintTo({ amount: 1_000_000 })
+            .accounts({ mint: mintAccount, mintAuthority: payer, token: sourceAccount })
+            .instruction();
+        ctx.sendInstruction(mintIx, [payer]);
+
+        const ix = await tokenClient.methods
+            .transferChecked({ amount: 400_000, decimals: 9 })
+            .accounts({ authority: payer, destination: destinationAccount, mint: mintAccount, source: sourceAccount })
+            .instruction();
+        ctx.sendInstruction(ix, [payer]);
+
+        const decoder = getTokenDecoder();
+        const sourceData = decoder.decode(ctx.requireEncodedAccount(sourceAccount).data);
+        const destData = decoder.decode(ctx.requireEncodedAccount(destinationAccount).data);
+        expect(sourceData.amount).toBe(600_000n);
+        expect(destData.amount).toBe(400_000n);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/transfer.test.ts
+++ b/packages/dynamic-instructions/tests/token/transfer.test.ts
@@ -1,0 +1,37 @@
+import { getTokenDecoder } from '@solana-program/token';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { createMint, createTokenAccount, tokenClient } from './token-test-utils';
+
+describe('Token Program: transfer', () => {
+    test('should transfer tokens between accounts', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+        const sourceAccount = ctx.createAccount();
+        const destinationAccount = ctx.createAccount();
+
+        await createMint(ctx, payer, mintAccount, payer);
+        await createTokenAccount(ctx, payer, sourceAccount, mintAccount, payer);
+        await createTokenAccount(ctx, payer, destinationAccount, mintAccount, payer);
+
+        const mintIx = await tokenClient.methods
+            .mintTo({ amount: 1_000_000 })
+            .accounts({ mint: mintAccount, mintAuthority: payer, token: sourceAccount })
+            .instruction();
+        ctx.sendInstruction(mintIx, [payer]);
+
+        const ix = await tokenClient.methods
+            .transfer({ amount: 400_000 })
+            .accounts({ authority: payer, destination: destinationAccount, source: sourceAccount })
+            .instruction();
+        ctx.sendInstruction(ix, [payer]);
+
+        const decoder = getTokenDecoder();
+        const sourceData = decoder.decode(ctx.requireEncodedAccount(sourceAccount).data);
+        const destData = decoder.decode(ctx.requireEncodedAccount(destinationAccount).data);
+        expect(sourceData.amount).toBe(600_000n);
+        expect(destData.amount).toBe(400_000n);
+    });
+});

--- a/packages/dynamic-instructions/tests/token/ui-amount-to-amount.test.ts
+++ b/packages/dynamic-instructions/tests/token/ui-amount-to-amount.test.ts
@@ -1,0 +1,24 @@
+import { getU64Decoder } from '@solana/codecs';
+import { describe, expect, test } from 'vitest';
+
+import { SvmTestContext } from '../test-utils';
+import { createMint, tokenClient } from './token-test-utils';
+
+describe('Token Program: uiAmountToAmount', () => {
+    test('should convert a UI amount string to a raw token amount', async () => {
+        const ctx = new SvmTestContext({ defaultPrograms: true });
+        const payer = ctx.createFundedAccount();
+        const mintAccount = ctx.createAccount();
+
+        await createMint(ctx, payer, mintAccount, payer);
+
+        const ix = await tokenClient.methods
+            .uiAmountToAmount({ uiAmount: '1' })
+            .accounts({ mint: mintAccount })
+            .instruction();
+
+        const meta = ctx.sendInstruction(ix, [payer]);
+        const rawAmount = getU64Decoder().decode(meta.returnData().data());
+        expect(rawAmount).toBe(1_000_000_000n);
+    });
+});


### PR DESCRIPTION
## Description

Support remaining accounts via argumentValueNode + Token Program e2e tests"                                                                                                                                                                                                                                                                  
  - Add support for InstructionRemainingAccountsNode when the value is an argumentValueNode, enabling instructions that accept variable-length account lists (e.g. multisig signers in the Token Program)                                          
  - Resolve remaining account roles (READONLY, READONLY_SIGNER, WRITABLE, WRITABLE_SIGNER) from the IDL node's isSigner/isWritable fields
  - Strip remaining account argument names before superstruct validation so they aren't rejected as unknown keys
  - Update type generation to include remaining account args as Address[] fields in the generated args types
  - Make method signatures with all-optional args accept args? instead of requiring an empty object
  - Refactor SvmTestContext to deduplicate sendInstruction/sendInstructions into a shared buildAndSend and return TransactionMetadata (enables return-data assertions)
  - Add comprehensive Token Program e2e tests covering 26 instructions: mint init, account init, transfers, burns, approvals, freeze/thaw, multisig, authority changes, native SOL sync, and amount conversion utilities

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [x] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Testing

- Run `pnpm test`

## Related Issues
Closes [HOO-292](https://linear.app/solana-fndn/issue/HOO-292/codama-add-support-for-token-program)

## Checklist
<!-- Verify that you have completed the following before requesting review -->
-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
