### PR TITLE
fix: PDA seed type mismatch when ix argument types differ from seed types

### DIFF
--- a/packages/dynamic-instructions/src/entities/visitors/pda-seed-value.ts
+++ b/packages/dynamic-instructions/src/entities/visitors/pda-seed-value.ts
@@ -11,6 +11,7 @@ import type {
     NumberValueNode,
     PublicKeyValueNode,
     StringValueNode,
+    TypeNode,
     Visitor,
 } from 'codama';
 import type { InstructionNode, RootNode } from 'codama';
@@ -30,6 +31,7 @@ type PdaSeedValueVisitorContext = {
     programId: Address;
     resolutionPath: ResolutionPath | undefined;
     root: RootNode;
+    seedTypeNode?: TypeNode;
 };
 
 /**
@@ -53,7 +55,7 @@ export function createPdaSeedValueVisitor(ctx: PdaSeedValueVisitorContext): Visi
     | 'stringValueNode'
     // TODO: consider supporting the rest of ValueNodes: [ArrayValueNode, ConstantValueNode, EnumValueNode, MapValueNode, NoneValueNode, SetValueNode, SomeValueNode, StructValueNode, TupleValueNode]
 > {
-    const { root, ixNode, programId } = ctx;
+    const { root, ixNode, programId, seedTypeNode } = ctx;
     const accountsInput = ctx.accountsInput ?? {};
     const argumentsInput = ctx.argumentsInput ?? {};
     const resolutionPath = ctx.resolutionPath ?? [];
@@ -96,12 +98,17 @@ export function createPdaSeedValueVisitor(ctx: PdaSeedValueVisitorContext): Visi
             if (!ixArgumentNode) {
                 throw new AccountError(`Missing instruction argument node for PDA seed: ${node.name}`);
             }
-            const codec = getNodeCodec([root, root.program, ixNode, ixArgumentNode]);
             const argInput = argumentsInput[node.name];
             if (argInput === undefined || argInput === null) {
                 throw new AccountError(`Missing argument for PDA seed ${node.name} in ${ixNode.name} instruction`);
             }
-            const transformer = createInputValueTransformer(ixArgumentNode.type, root, {
+
+            // Use the PDA seed's declared type (e.g. plain stringTypeNode) rather than
+            // the instruction argument's type (e.g. sizePrefixTypeNode) so the seed
+            // bytes match what the on-chain program derives.
+            const typeNode = seedTypeNode ?? ixArgumentNode.type;
+            const codec = getNodeCodec([root, root.program, ixNode, { ...ixArgumentNode, type: typeNode }]);
+            const transformer = createInputValueTransformer(typeNode, root, {
                 bytesEncoding: 'base16',
             });
             const transformedInput = transformer(argInput);

--- a/packages/dynamic-instructions/src/features/instruction-encoding/pda.ts
+++ b/packages/dynamic-instructions/src/features/instruction-encoding/pda.ts
@@ -134,6 +134,7 @@ function resolveVariablePdaSeed({
         programId,
         resolutionPath: resolutionPath ?? [],
         root,
+        seedTypeNode: seedNode.type,
     });
 
     return visitOrElse(variableSeedValueNode.value, visitor, node => {

--- a/packages/dynamic-instructions/tests/anchor/programs/example/src/lib.rs
+++ b/packages/dynamic-instructions/tests/anchor/programs/example/src/lib.rs
@@ -60,6 +60,12 @@ pub mod example {
     pub fn nested_example(ctx: Context<NestedStructsAndEnums>, input: StructAndEnumsInput) -> Result<()> {
         nested_example::handler(ctx, input)
     }
+
+    pub fn string_seed_pda(ctx: Context<StringSeedPda>, name: String, id: u64) -> Result<()> {
+        ctx.accounts.pda_account.input = id;
+        ctx.accounts.pda_account.bump = ctx.bumps.pda_account;
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -254,6 +260,28 @@ pub struct TwoNodeCyclePda<'info> {
     )]
     pub pda_b: Account<'info, DataAccount1>,
 
+    pub system_program: Program<'info, System>,
+}
+
+// Reproducer for the PDA seed type mismatch:
+// The `name` argument is a Rust `String`, which Borsh serializes with a u32 length prefix
+// (sizePrefixTypeNode in Codama). But the PDA seed uses `name.as_bytes()` — raw UTF-8 bytes
+// without any prefix (stringTypeNode in Codama). Without the proper seedTypeNode in
+// pda-seed-value.ts, the library would encode the seed with the length prefix, deriving
+// the wrong PDA address.
+#[derive(Accounts)]
+#[instruction(name: String, id: u64)]
+pub struct StringSeedPda<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    #[account(
+        init,
+        payer = signer,
+        space = 8 + DataAccount1::INIT_SPACE,
+        seeds = [&id.to_le_bytes(), name.as_bytes()],
+        bump
+    )]
+    pub pda_account: Account<'info, DataAccount1>,
     pub system_program: Program<'info, System>,
 }
 

--- a/packages/dynamic-instructions/tests/anchor/tests/idl.spec.ts
+++ b/packages/dynamic-instructions/tests/anchor/tests/idl.spec.ts
@@ -1,6 +1,6 @@
 import { getNodeCodec } from '@codama/dynamic-codecs';
 import { type Address, getAddressEncoder, getProgramDerivedAddress } from '@solana/addresses';
-import { type Option, unwrapOption } from '@solana/codecs';
+import { getU64Encoder, type Option, unwrapOption } from '@solana/codecs';
 import type { RootNode } from 'codama';
 import { beforeEach, describe, expect, test } from 'vitest';
 
@@ -211,6 +211,31 @@ describe('anchor-example: commonIxs', () => {
         });
 
         ctx.sendInstruction(ix, [payer]);
+    });
+
+    describe('stringSeedPda', () => {
+        test('should derive PDA using raw string seed bytes (not size-prefixed)', async () => {
+            const name = 'hello';
+            const id = 7;
+
+            const ix = await programClient.methods
+                .stringSeedPda({ id, name })
+                .accounts({ signer: payer })
+                .instruction();
+
+            ctx.sendInstruction(ix, [payer]);
+
+            const [expectedPda] = await getProgramDerivedAddress({
+                programAddress: programClient.programAddress,
+                seeds: [getU64Encoder().encode(id), name],
+            });
+
+            const account = ctx.requireEncodedAccount(expectedPda);
+            expect(account.owner).toBe(programClient.programAddress);
+
+            const decoded = decodeDataAccount1(programClient.root, account.data);
+            expect(decoded.input).toBe(7n);
+        });
     });
 
     describe('Circular Dependency Detection', () => {

--- a/packages/dynamic-instructions/tests/idls/example-idl.json
+++ b/packages/dynamic-instructions/tests/idls/example-idl.json
@@ -1009,6 +1009,144 @@
             },
             {
                 "kind": "instructionNode",
+                "name": "stringSeedPda",
+                "docs": [],
+                "optionalAccountStrategy": "programId",
+                "accounts": [
+                    {
+                        "kind": "instructionAccountNode",
+                        "name": "signer",
+                        "isWritable": true,
+                        "isSigner": true,
+                        "isOptional": false,
+                        "docs": []
+                    },
+                    {
+                        "kind": "instructionAccountNode",
+                        "name": "pdaAccount",
+                        "isWritable": true,
+                        "isSigner": false,
+                        "isOptional": false,
+                        "docs": [],
+                        "defaultValue": {
+                            "kind": "pdaValueNode",
+                            "pda": {
+                                "kind": "pdaNode",
+                                "name": "pdaAccount",
+                                "docs": [],
+                                "seeds": [
+                                    {
+                                        "kind": "variablePdaSeedNode",
+                                        "name": "id",
+                                        "docs": [],
+                                        "type": {
+                                            "kind": "numberTypeNode",
+                                            "format": "u64",
+                                            "endian": "le"
+                                        }
+                                    },
+                                    {
+                                        "kind": "variablePdaSeedNode",
+                                        "name": "name",
+                                        "docs": [],
+                                        "type": {
+                                            "kind": "stringTypeNode",
+                                            "encoding": "utf8"
+                                        }
+                                    }
+                                ]
+                            },
+                            "seeds": [
+                                {
+                                    "kind": "pdaSeedValueNode",
+                                    "name": "id",
+                                    "value": {
+                                        "kind": "argumentValueNode",
+                                        "name": "id"
+                                    }
+                                },
+                                {
+                                    "kind": "pdaSeedValueNode",
+                                    "name": "name",
+                                    "value": {
+                                        "kind": "argumentValueNode",
+                                        "name": "name"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "kind": "instructionAccountNode",
+                        "name": "systemProgram",
+                        "isWritable": false,
+                        "isSigner": false,
+                        "isOptional": false,
+                        "docs": [],
+                        "defaultValue": {
+                            "kind": "publicKeyValueNode",
+                            "publicKey": "11111111111111111111111111111111",
+                            "identifier": "systemProgram"
+                        }
+                    }
+                ],
+                "arguments": [
+                    {
+                        "kind": "instructionArgumentNode",
+                        "name": "discriminator",
+                        "defaultValueStrategy": "omitted",
+                        "docs": [],
+                        "type": {
+                            "kind": "fixedSizeTypeNode",
+                            "size": 8,
+                            "type": {
+                                "kind": "bytesTypeNode"
+                            }
+                        },
+                        "defaultValue": {
+                            "kind": "bytesValueNode",
+                            "data": "be1f479d57a0852b",
+                            "encoding": "base16"
+                        }
+                    },
+                    {
+                        "kind": "instructionArgumentNode",
+                        "name": "name",
+                        "docs": [],
+                        "type": {
+                            "kind": "sizePrefixTypeNode",
+                            "type": {
+                                "kind": "stringTypeNode",
+                                "encoding": "utf8"
+                            },
+                            "prefix": {
+                                "kind": "numberTypeNode",
+                                "format": "u32",
+                                "endian": "le"
+                            }
+                        }
+                    },
+                    {
+                        "kind": "instructionArgumentNode",
+                        "name": "id",
+                        "docs": [],
+                        "type": {
+                            "kind": "numberTypeNode",
+                            "format": "u64",
+                            "endian": "le"
+                        }
+                    }
+                ],
+                "discriminators": [
+                    {
+                        "kind": "fieldDiscriminatorNode",
+                        "name": "discriminator",
+                        "offset": 0
+                    }
+                ]
+            },
+            {
+                "kind": "instructionNode",
                 "name": "twoNodeCyclePda",
                 "docs": [],
                 "optionalAccountStrategy": "programId",


### PR DESCRIPTION
## Description
The core issue: when an instruction argument has a different serialization type than its corresponding PDA seed, the library was using the argument's type to encode the seed, producing wrong PDA addresses.

Bug fix: PDA seed type mismatch when instruction argument types differ from seed types.
                                                                                                                                                          
Added an example: A Rust String argument is Borsh-serialized with a u32 length prefix (sizePrefixTypeNode in Codama), but when used as a PDA seed via name.as_bytes(), it's raw UTF-8 bytes with no prefix (stringTypeNode). The library was encoding the seed with the length prefix, deriving the wrong PDA.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Testing
- run `pnpm test`

## Related Issues
N/A

## Checklist
<!-- Verify that you have completed the following before requesting review -->
-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
