### PR TITLE
feat: throw descriptive errors for missing instructions and PDAs

### DIFF
--- a/packages/dynamic-instructions/src/features/program-client/create-program-client.ts
+++ b/packages/dynamic-instructions/src/features/program-client/create-program-client.ts
@@ -80,8 +80,8 @@ export function createProgramClient<TClient = ProgramClient>(
 
                 return (args?: ArgumentsInput) => new MethodsBuilder(root, ixNode, args) as ProgramMethodBuilder;
             },
-            has(_target, prop) {
-                return typeof prop === 'string' && instructions.has(prop);
+            has(target, prop) {
+                return Reflect.has(target, prop) || (typeof prop === 'string' && instructions.has(prop));
             },
         },
     ) as ProgramClient['methods'];
@@ -102,8 +102,8 @@ export function createProgramClient<TClient = ProgramClient>(
 
                 return (seeds?: Record<string, unknown>) => deriveStandalonePDA(root, pdaNode, programAddress, seeds);
             },
-            has(_target, prop) {
-                return typeof prop === 'string' && pdaNodes.has(prop);
+            has(target, prop) {
+                return Reflect.has(target, prop) || (typeof prop === 'string' && pdaNodes.has(prop));
             },
         },
     ) as ProgramClient['pdas'];

--- a/packages/dynamic-instructions/src/features/program-client/create-program-client.ts
+++ b/packages/dynamic-instructions/src/features/program-client/create-program-client.ts
@@ -5,6 +5,7 @@ import { createFromJson } from 'codama';
 
 import type { AddressInput } from '../../shared/address';
 import { toAddress } from '../../shared/address';
+import { DynamicInstructionsError } from '../../shared/errors';
 import type { AccountsInput, ArgumentsInput, ResolversInput } from '../../shared/types';
 import { collectPdaNodes } from './collect-pdas';
 import { deriveStandalonePDA } from './derive-standalone-pda';
@@ -67,14 +68,20 @@ export function createProgramClient<TClient = ProgramClient>(
         {},
         {
             get(_target, prop) {
-                // Avoid thenable behavior when people `await program.methods`.
-                if (prop === 'then') return undefined;
-                if (typeof prop !== 'string') return undefined;
+                if (typeof prop !== 'string' || PASSTHROUGH_PROPS.has(prop)) return undefined;
 
                 const ixNode = instructions.get(prop);
-                if (!ixNode) return undefined;
+                if (!ixNode) {
+                    const available = [...instructions.keys()].join(', ');
+                    throw new DynamicInstructionsError(
+                        `Instruction "${prop}" not found in IDL. Available instructions: ${available}`,
+                    );
+                }
 
                 return (args?: ArgumentsInput) => new MethodsBuilder(root, ixNode, args) as ProgramMethodBuilder;
+            },
+            has(_target, prop) {
+                return typeof prop === 'string' && instructions.has(prop);
             },
         },
     ) as ProgramClient['methods'];
@@ -85,13 +92,18 @@ export function createProgramClient<TClient = ProgramClient>(
         {},
         {
             get(_target, prop) {
-                if (prop === 'then') return undefined;
-                if (typeof prop !== 'string') return undefined;
+                if (typeof prop !== 'string' || PASSTHROUGH_PROPS.has(prop)) return undefined;
 
                 const pdaNode = pdaNodes.get(prop);
-                if (!pdaNode) return undefined;
+                if (!pdaNode) {
+                    const available = [...pdaNodes.keys()].join(', ');
+                    throw new DynamicInstructionsError(`PDA "${prop}" not found in IDL. Available PDAs: ${available}`);
+                }
 
                 return (seeds?: Record<string, unknown>) => deriveStandalonePDA(root, pdaNode, programAddress, seeds);
+            },
+            has(_target, prop) {
+                return typeof prop === 'string' && pdaNodes.has(prop);
             },
         },
     ) as ProgramClient['pdas'];
@@ -104,3 +116,5 @@ export function createProgramClient<TClient = ProgramClient>(
         root,
     } as unknown as TClient;
 }
+
+const PASSTHROUGH_PROPS = new Set<string>(['then', 'toJSON', 'valueOf', 'toString']);

--- a/packages/dynamic-instructions/tests/features/program-client/create-program-client.test.ts
+++ b/packages/dynamic-instructions/tests/features/program-client/create-program-client.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'vitest';
+
+import { DynamicInstructionsError } from '../../../src/shared/errors';
+import type { SystemProgramClient } from '../../generated/system-program-idl-types';
+import { createTestProgramClient } from '../../test-utils';
+
+describe('createProgramClient', () => {
+    describe('methods', () => {
+        const programClient = createTestProgramClient('system-program-idl.json');
+
+        test('throws when accessing a non-existent instruction', () => {
+            expect(() => programClient.methods.nonExistentMethod).toThrow(DynamicInstructionsError);
+            expect(() => programClient.methods.nonExistentMethod).toThrow(
+                /Instruction "nonExistentMethod" not found in IDL/,
+            );
+        });
+
+        test('error message lists available instructions', () => {
+            expect(() => programClient.methods.nonExistentMethod).toThrow(/Available instructions:/);
+            expect(() => programClient.methods.nonExistentMethod).toThrow(/transferSol/);
+        });
+
+        test('returns a builder for a valid instruction', () => {
+            const typedClient = createTestProgramClient<SystemProgramClient>('system-program-idl.json');
+            const builder = typedClient.methods.transferSol({ amount: 1000 });
+            expect(builder).toBeDefined();
+            expect(typeof builder.accounts).toBe('function');
+            expect(typeof builder.instruction).toBe('function');
+        });
+
+        test('supports "in" operator for existing instructions', () => {
+            expect('transferSol' in programClient.methods).toBe(true);
+            expect('nonExistentMethod' in programClient.methods).toBe(false);
+        });
+
+        test('does not throw when awaited directly', async () => {
+            // eslint-disable-next-line @typescript-eslint/await-thenable
+            const result = await programClient.methods;
+            expect(result).toBeDefined();
+        });
+
+        test('does not throw when serialized with JSON.stringify', () => {
+            expect(() => JSON.stringify(programClient.methods)).not.toThrow();
+        });
+    });
+
+    describe('pdas', () => {
+        const pdaClient = createTestProgramClient('mpl-token-metadata-idl.json');
+
+        test('throws when accessing a non-existent PDA', () => {
+            expect(() => pdaClient.pdas.nonExistentPda).toThrow(DynamicInstructionsError);
+            expect(() => pdaClient.pdas.nonExistentPda).toThrow(/PDA "nonExistentPda" not found in IDL/);
+        });
+
+        test('error message lists available PDAs', () => {
+            expect(() => pdaClient.pdas.nonExistentPda).toThrow(/Available PDAs:/);
+        });
+
+        test('supports "in" operator for existing PDAs', () => {
+            expect('metadata' in pdaClient.pdas).toBe(true);
+            expect('nonExistentPda' in pdaClient.pdas).toBe(false);
+        });
+
+        test('does not throw when awaited directly', async () => {
+            // eslint-disable-next-line @typescript-eslint/await-thenable
+            const result = await pdaClient.pdas;
+            expect(result).toBeDefined();
+        });
+
+        test('does not throw when serialized with JSON.stringify', () => {
+            expect(() => JSON.stringify(pdaClient.pdas)).not.toThrow();
+        });
+    });
+});

--- a/packages/dynamic-instructions/tests/features/program-client/create-program-client.test.ts
+++ b/packages/dynamic-instructions/tests/features/program-client/create-program-client.test.ts
@@ -33,6 +33,13 @@ describe('createProgramClient', () => {
             expect('nonExistentMethod' in programClient.methods).toBe(false);
         });
 
+        test('should preserve standard object semantics for prototype properties with "in" operator', () => {
+            expect('toString' in programClient.methods).toBe(true);
+            expect('valueOf' in programClient.methods).toBe(true);
+            expect('constructor' in programClient.methods).toBe(true);
+            expect('hasOwnProperty' in programClient.methods).toBe(true);
+        });
+
         test('does not throw when awaited directly', async () => {
             // eslint-disable-next-line @typescript-eslint/await-thenable
             const result = await programClient.methods;
@@ -59,6 +66,13 @@ describe('createProgramClient', () => {
         test('supports "in" operator for existing PDAs', () => {
             expect('metadata' in pdaClient.pdas).toBe(true);
             expect('nonExistentPda' in pdaClient.pdas).toBe(false);
+        });
+
+        test('should preserve standard object semantics for prototype properties with "in" operator', () => {
+            expect('toString' in pdaClient.pdas).toBe(true);
+            expect('valueOf' in pdaClient.pdas).toBe(true);
+            expect('constructor' in pdaClient.pdas).toBe(true);
+            expect('hasOwnProperty' in pdaClient.pdas).toBe(true);
         });
 
         test('does not throw when awaited directly', async () => {

--- a/packages/dynamic-instructions/tests/features/program-client/create-program-client.test.ts
+++ b/packages/dynamic-instructions/tests/features/program-client/create-program-client.test.ts
@@ -16,8 +16,34 @@ describe('createProgramClient', () => {
         });
 
         test('error message lists available instructions', () => {
-            expect(() => programClient.methods.nonExistentMethod).toThrow(/Available instructions:/);
-            expect(() => programClient.methods.nonExistentMethod).toThrow(/transferSol/);
+            try {
+                // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+                programClient.methods.nonExistentMethod;
+                expect.unreachable('should have thrown');
+            } catch (error) {
+                const message = (error as Error).message;
+                expect(message).toContain('Available instructions:');
+
+                const allInstructions = [
+                    'createAccount',
+                    'assign',
+                    'transferSol',
+                    'createAccountWithSeed',
+                    'advanceNonceAccount',
+                    'withdrawNonceAccount',
+                    'initializeNonceAccount',
+                    'authorizeNonceAccount',
+                    'allocate',
+                    'allocateWithSeed',
+                    'assignWithSeed',
+                    'transferSolWithSeed',
+                    'upgradeNonceAccount',
+                ];
+
+                for (const ix of allInstructions) {
+                    expect(message).toContain(ix);
+                }
+            }
         });
 
         test('returns a builder for a valid instruction', () => {


### PR DESCRIPTION
## Description

Throw descriptive errors for missing instructions and PDAs 
  - Proxy `get` traps now throw `DynamicInstructionsError` with available keys listed when accessing non-existent instructions or PDAs, instead of silently returning `undefined`            
  - Added `PASSTHROUGH_PROPS` set so runtime property accesses (`then`, `toJSON`, `valueOf`, `toString`) safely return `undefined` without throwing                              
  - Added `has` proxy traps to support the `in` operator for checking instruction/PDA existence
  
## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] New feature

## Testing
  - `pnpm test`

## Related Issues

<!-- Link to any related issues this PR addresses -->
Closes https://github.com/hoodieshq/codama-dynamic-instructions-demo/issues/41

## Checklist
<!-- Verify that you have completed the following before requesting review -->
-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
