### PR TITLE
fix: add default case error for TypeNode validators

### DIFF
--- a/packages/dynamic-instructions/src/features/instruction-encoding/validators.ts
+++ b/packages/dynamic-instructions/src/features/instruction-encoding/validators.ts
@@ -115,7 +115,7 @@ function createValidatorForTypeNode(nodeName: string, node: TypeNode, definedTyp
             return boolean() as StructUnknown;
         }
         case 'numberTypeNode': {
-            const format = (node as TypeNode & { format?: string }).format;
+            const format = node.format;
             if (format === 'u64' || format === 'u128' || format === 'i64' || format === 'i128') {
                 return NumberOrBigintValidator;
             }
@@ -236,6 +236,11 @@ function createValidatorForTypeNode(nodeName: string, node: TypeNode, definedTyp
         }
         case 'solAmountTypeNode': {
             return AmountTypeValidator(nodeName);
+        }
+        default: {
+            throw new Error(
+                `Validator for TypeNode "${nodeName}" kind: ${(node as { kind: string })?.kind} is not implemented!`,
+            );
         }
     }
 }

--- a/packages/dynamic-instructions/tests/features/instruction-encoding/validators.test.ts
+++ b/packages/dynamic-instructions/tests/features/instruction-encoding/validators.test.ts
@@ -1,0 +1,19 @@
+import type { InstructionArgumentNode } from '@codama/nodes';
+import { describe, expect, test } from 'vitest';
+
+import { createIxArgumentsValidator } from '../../../src/features/instruction-encoding/validators';
+
+describe('Validators', () => {
+    test('should throw for unsupported TypeNode kind', () => {
+        const fakeIxArguments = [
+            {
+                name: 'testArg',
+                type: { kind: 'fooBarTypeNode' },
+            },
+        ] as unknown as InstructionArgumentNode[];
+
+        expect(() => createIxArgumentsValidator('testInstruction', fakeIxArguments, [])).toThrow(
+            'Validator for TypeNode "testInstruction_testArg_0" kind: fooBarTypeNode is not implemented!',
+        );
+    });
+});


### PR DESCRIPTION
## Description

Throw descriptive error as default case in `createValidatorForTypeNode`.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Testing

<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->
https://github.com/hoodieshq/codama-dynamic-instructions-demo/issues/50

## Checklist
<!-- Verify that you have completed the following before requesting review -->
-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
